### PR TITLE
feat: account model + REST API

### DIFF
--- a/backend/src/handlers/accounts.rs
+++ b/backend/src/handlers/accounts.rs
@@ -1,0 +1,75 @@
+use axum::{extract::{Path, State}, http::StatusCode, Json};
+use sqlx::SqlitePool;
+use crate::{errors::AppError, models::account::{Account, CreateAccount}};
+
+pub async fn list_accounts(
+    State(pool): State<SqlitePool>,
+) -> Result<Json<Vec<Account>>, AppError> {
+    Account::list(&pool).await.map(Json)
+}
+
+pub async fn create_account(
+    State(pool): State<SqlitePool>,
+    Json(payload): Json<CreateAccount>,
+) -> Result<(StatusCode, Json<Account>), AppError> {
+    if payload.name.trim().is_empty() {
+        return Err(AppError::BadRequest("name cannot be empty".to_string()));
+    }
+    Account::create(&pool, &payload.name)
+        .await
+        .map(|a| (StatusCode::CREATED, Json(a)))
+}
+
+pub async fn delete_account(
+    State(pool): State<SqlitePool>,
+    Path(id): Path<i64>,
+) -> Result<StatusCode, AppError> {
+    Account::delete(&pool, id).await?;
+    Ok(StatusCode::OK)
+}
+
+#[cfg(test)]
+mod tests {
+    use axum_test::TestServer;
+    use serde_json::json;
+    use crate::routes::create_router;
+    use crate::db;
+
+    async fn test_server() -> TestServer {
+        let pool = db::init_pool("sqlite::memory:").await;
+        db::run_migrations(&pool).await;
+        TestServer::new(create_router(pool)).unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_create_account() {
+        let server = test_server().await;
+        let res = server.post("/api/accounts")
+            .json(&json!({ "name": "Fidelity" }))
+            .await;
+        res.assert_status(axum::http::StatusCode::CREATED);
+        let body = res.json::<serde_json::Value>();
+        assert_eq!(body["name"], "Fidelity");
+        assert!(body["id"].is_number());
+    }
+
+    #[tokio::test]
+    async fn test_list_accounts() {
+        let server = test_server().await;
+        server.post("/api/accounts").json(&json!({ "name": "Fidelity" })).await;
+        let res = server.get("/api/accounts").await;
+        res.assert_status_ok();
+        let body = res.json::<serde_json::Value>();
+        assert_eq!(body.as_array().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_delete_account() {
+        let server = test_server().await;
+        let create = server.post("/api/accounts")
+            .json(&json!({ "name": "TDA" })).await;
+        let id = create.json::<serde_json::Value>()["id"].as_i64().unwrap();
+        let res = server.delete(&format!("/api/accounts/{}", id)).await;
+        res.assert_status_ok();
+    }
+}

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -1,1 +1,1 @@
-// placeholder
+pub mod accounts;

--- a/backend/src/models/account.rs
+++ b/backend/src/models/account.rs
@@ -1,0 +1,47 @@
+use serde::{Deserialize, Serialize};
+use sqlx::SqlitePool;
+use crate::errors::AppError;
+
+#[derive(Debug, Serialize, Deserialize, sqlx::FromRow)]
+pub struct Account {
+    pub id: i64,
+    pub name: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateAccount {
+    pub name: String,
+}
+
+impl Account {
+    pub async fn create(pool: &SqlitePool, name: &str) -> Result<Account, AppError> {
+        let account = sqlx::query_as::<_, Account>(
+            "INSERT INTO accounts (name) VALUES (?) RETURNING id, name, created_at"
+        )
+        .bind(name)
+        .fetch_one(pool)
+        .await?;
+        Ok(account)
+    }
+
+    pub async fn list(pool: &SqlitePool) -> Result<Vec<Account>, AppError> {
+        let accounts = sqlx::query_as::<_, Account>(
+            "SELECT id, name, created_at FROM accounts ORDER BY created_at"
+        )
+        .fetch_all(pool)
+        .await?;
+        Ok(accounts)
+    }
+
+    pub async fn delete(pool: &SqlitePool, id: i64) -> Result<(), AppError> {
+        let result = sqlx::query("DELETE FROM accounts WHERE id = ?")
+            .bind(id)
+            .execute(pool)
+            .await?;
+        if result.rows_affected() == 0 {
+            return Err(AppError::NotFound);
+        }
+        Ok(())
+    }
+}

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -1,1 +1,1 @@
-// placeholder
+pub mod account;

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -1,9 +1,12 @@
-use axum::Router;
+use axum::{routing::{delete, get}, Router};
 use sqlx::SqlitePool;
 use tower_http::cors::CorsLayer;
+use crate::handlers::accounts;
 
 pub fn create_router(pool: SqlitePool) -> Router {
     Router::new()
+        .route("/api/accounts", get(accounts::list_accounts).post(accounts::create_account))
+        .route("/api/accounts/:id", delete(accounts::delete_account))
         .layer(CorsLayer::permissive())
         .with_state(pool)
 }


### PR DESCRIPTION
## Summary
- Account model with create, list, delete operations
- REST handlers: `GET/POST /api/accounts`, `DELETE /api/accounts/:id`
- 3 integration tests (create, list, delete) — all passing
- Uses runtime SQLx queries (not compile-time macros) to avoid DATABASE_URL at build time

## Test plan
- [x] `cargo test accounts` — 3/3 pass
- [x] Working tree clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)