### PR TITLE
feat: PUT and CALL trade handlers

### DIFF
--- a/backend/src/handlers/calls.rs
+++ b/backend/src/handlers/calls.rs
@@ -1,0 +1,295 @@
+use axum::{extract::{Path, State}, http::StatusCode, Json};
+use serde::Deserialize;
+use serde_json::json;
+use sqlx::SqlitePool;
+
+use crate::{
+    errors::AppError,
+    models::{
+        share_lot::ShareLot,
+        trade::{CreateTrade, Trade},
+    },
+};
+
+#[derive(Deserialize)]
+pub struct OpenCall {
+    pub share_lot_id: i64,
+    pub ticker: String,
+    pub strike_price: f64,
+    pub expiry_date: String,
+    pub open_date: String,
+    pub premium_received: f64,
+    pub fees_open: f64,
+}
+
+#[derive(Deserialize)]
+pub struct CloseCall {
+    pub action: String,
+    pub close_date: Option<String>,
+    pub close_premium: Option<f64>,
+    pub fees_close: Option<f64>,
+}
+
+pub async fn list_share_lots(
+    State(pool): State<SqlitePool>,
+    Path(account_id): Path<i64>,
+) -> Result<Json<Vec<ShareLot>>, AppError> {
+    ShareLot::list_active(&pool, account_id).await.map(Json)
+}
+
+pub async fn open_call(
+    State(pool): State<SqlitePool>,
+    Path(account_id): Path<i64>,
+    Json(payload): Json<OpenCall>,
+) -> Result<(StatusCode, Json<Trade>), AppError> {
+    // Verify the lot belongs to this account and is ACTIVE
+    let lot = ShareLot::get(&pool, payload.share_lot_id).await?;
+    if lot.account_id != account_id {
+        return Err(AppError::BadRequest("Share lot does not belong to this account".to_string()));
+    }
+    if lot.status != "ACTIVE" {
+        return Err(AppError::BadRequest("Share lot is not ACTIVE".to_string()));
+    }
+
+    let input = CreateTrade {
+        account_id,
+        trade_type: "CALL".to_string(),
+        ticker: payload.ticker,
+        strike_price: payload.strike_price,
+        expiry_date: payload.expiry_date,
+        open_date: payload.open_date,
+        premium_received: payload.premium_received,
+        fees_open: payload.fees_open,
+        share_lot_id: Some(payload.share_lot_id),
+    };
+    let trade = Trade::create(&pool, &input).await?;
+    Ok((StatusCode::CREATED, Json(trade)))
+}
+
+pub async fn close_call(
+    State(pool): State<SqlitePool>,
+    Path(trade_id): Path<i64>,
+    Json(payload): Json<CloseCall>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    let trade = Trade::get(&pool, trade_id).await?;
+
+    if trade.trade_type != "CALL" {
+        return Err(AppError::BadRequest("Trade is not a CALL".to_string()));
+    }
+    if trade.status != "OPEN" {
+        return Err(AppError::BadRequest("Trade is not OPEN".to_string()));
+    }
+
+    let lot_id = trade
+        .share_lot_id
+        .ok_or_else(|| AppError::BadRequest("CALL trade has no share_lot_id".to_string()))?;
+
+    match payload.action.as_str() {
+        "EXPIRED" | "BOUGHT_BACK" => {
+            let (status, close_premium) = if payload.action == "BOUGHT_BACK" {
+                let cp = payload.close_premium.ok_or_else(|| {
+                    AppError::BadRequest("close_premium required for BOUGHT_BACK".to_string())
+                })?;
+                ("BOUGHT_BACK", Some(cp))
+            } else {
+                ("EXPIRED", None)
+            };
+
+            let updated = Trade::close(
+                &pool,
+                trade_id,
+                status,
+                close_premium,
+                payload.fees_close,
+                payload.close_date,
+            )
+            .await?;
+
+            let net = updated.net_premium().unwrap_or(0.0);
+            ShareLot::reduce_cost_basis(&pool, lot_id, net).await?;
+            let lot = ShareLot::get(&pool, lot_id).await?;
+
+            Ok(Json(json!({
+                "trade": updated,
+                "share_lot": lot
+            })))
+        }
+        "CALLED_AWAY" => {
+            let updated = Trade::close(
+                &pool,
+                trade_id,
+                "CALLED_AWAY",
+                payload.close_premium,
+                payload.fees_close,
+                payload.close_date,
+            )
+            .await?;
+
+            let net = updated.net_premium().unwrap_or(0.0);
+            ShareLot::reduce_cost_basis(&pool, lot_id, net).await?;
+            ShareLot::mark_called_away(&pool, lot_id).await?;
+
+            Ok(Json(json!(updated)))
+        }
+        _ => Err(AppError::BadRequest(format!("Invalid action: {}", payload.action))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::StatusCode;
+    use axum_test::TestServer;
+    use serde_json::json;
+
+    use crate::db;
+    use crate::routes::create_router;
+
+    /// Creates account -> PUT -> assigns PUT -> returns (server, account_id, lot_id)
+    async fn server_with_lot() -> (TestServer, i64, i64) {
+        let pool = db::init_pool("sqlite::memory:").await;
+        db::run_migrations(&pool).await;
+
+        let s = TestServer::new(create_router(pool.clone())).unwrap();
+
+        // Create account
+        let res = s
+            .post("/api/accounts")
+            .json(&json!({"name": "Test"}))
+            .await;
+        let acct_id = res.json::<serde_json::Value>()["id"].as_i64().unwrap();
+
+        // Open PUT
+        let res = s
+            .post(&format!("/api/accounts/{}/puts", acct_id))
+            .json(&json!({
+                "ticker": "AAPL",
+                "strike_price": 150.0,
+                "expiry_date": "2025-02-21",
+                "open_date": "2025-01-15",
+                "premium_received": 200.0,
+                "fees_open": 1.30
+            }))
+            .await;
+        let trade_id = res.json::<serde_json::Value>()["id"].as_i64().unwrap();
+
+        // Assign PUT to create share lot
+        let res = s
+            .post(&format!("/api/trades/puts/{}/close", trade_id))
+            .json(&json!({
+                "action": "ASSIGNED",
+                "close_date": "2025-02-21"
+            }))
+            .await;
+        let body = res.json::<serde_json::Value>();
+        let lot_id = body["share_lot"]["id"].as_i64().unwrap();
+
+        // Create a new server from the same pool for test isolation
+        let s2 = TestServer::new(create_router(pool)).unwrap();
+        (s2, acct_id, lot_id)
+    }
+
+    #[tokio::test]
+    async fn test_open_call_on_lot() {
+        let (server, acct_id, lot_id) = server_with_lot().await;
+
+        let res = server
+            .post(&format!("/api/accounts/{}/calls", acct_id))
+            .json(&json!({
+                "share_lot_id": lot_id,
+                "ticker": "AAPL",
+                "strike_price": 155.0,
+                "expiry_date": "2025-03-21",
+                "open_date": "2025-02-22",
+                "premium_received": 150.0,
+                "fees_open": 1.30
+            }))
+            .await;
+        res.assert_status(StatusCode::CREATED);
+        let body = res.json::<serde_json::Value>();
+        assert_eq!(body["status"], "OPEN");
+        assert_eq!(body["trade_type"], "CALL");
+        assert_eq!(body["share_lot_id"], lot_id);
+    }
+
+    #[tokio::test]
+    async fn test_close_call_expired_reduces_cost_basis() {
+        let (server, acct_id, lot_id) = server_with_lot().await;
+
+        // Check initial adjusted cost basis of the lot
+        let lots_res = server
+            .get(&format!("/api/accounts/{}/share-lots", acct_id))
+            .await;
+        let lots = lots_res.json::<serde_json::Value>();
+        let initial_cb = lots.as_array().unwrap()[0]["adjusted_cost_basis"]
+            .as_f64()
+            .unwrap();
+
+        // Open a CALL
+        let res = server
+            .post(&format!("/api/accounts/{}/calls", acct_id))
+            .json(&json!({
+                "share_lot_id": lot_id,
+                "ticker": "AAPL",
+                "strike_price": 155.0,
+                "expiry_date": "2025-03-21",
+                "open_date": "2025-02-22",
+                "premium_received": 150.0,
+                "fees_open": 1.30
+            }))
+            .await;
+        let call_id = res.json::<serde_json::Value>()["id"].as_i64().unwrap();
+
+        // Close as EXPIRED
+        let res = server
+            .post(&format!("/api/trades/calls/{}/close", call_id))
+            .json(&json!({
+                "action": "EXPIRED",
+                "close_date": "2025-03-21"
+            }))
+            .await;
+        res.assert_status(StatusCode::OK);
+        let body = res.json::<serde_json::Value>();
+
+        let new_cb = body["share_lot"]["adjusted_cost_basis"].as_f64().unwrap();
+        // net_premium = 150 - 1.30 = 148.70, reduction = 148.70 / 100 = 1.487
+        let expected_reduction = 1.487;
+        assert!((initial_cb - new_cb - expected_reduction).abs() < 0.001);
+    }
+
+    #[tokio::test]
+    async fn test_close_call_called_away_marks_lot() {
+        let (server, acct_id, lot_id) = server_with_lot().await;
+
+        // Open a CALL
+        let res = server
+            .post(&format!("/api/accounts/{}/calls", acct_id))
+            .json(&json!({
+                "share_lot_id": lot_id,
+                "ticker": "AAPL",
+                "strike_price": 155.0,
+                "expiry_date": "2025-03-21",
+                "open_date": "2025-02-22",
+                "premium_received": 150.0,
+                "fees_open": 1.30
+            }))
+            .await;
+        let call_id = res.json::<serde_json::Value>()["id"].as_i64().unwrap();
+
+        // Close as CALLED_AWAY
+        let res = server
+            .post(&format!("/api/trades/calls/{}/close", call_id))
+            .json(&json!({
+                "action": "CALLED_AWAY",
+                "close_date": "2025-03-21"
+            }))
+            .await;
+        res.assert_status(StatusCode::OK);
+
+        // Verify active lots is empty
+        let lots_res = server
+            .get(&format!("/api/accounts/{}/share-lots", acct_id))
+            .await;
+        let lots = lots_res.json::<serde_json::Value>();
+        assert_eq!(lots.as_array().unwrap().len(), 0);
+    }
+}

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -1,1 +1,3 @@
 pub mod accounts;
+pub mod calls;
+pub mod puts;

--- a/backend/src/handlers/puts.rs
+++ b/backend/src/handlers/puts.rs
@@ -1,0 +1,250 @@
+use axum::{extract::{Path, State}, http::StatusCode, Json};
+use serde::Deserialize;
+use serde_json::json;
+use sqlx::SqlitePool;
+
+use crate::{
+    errors::AppError,
+    models::{
+        share_lot::ShareLot,
+        trade::{CreateTrade, Trade},
+    },
+};
+
+#[derive(Deserialize)]
+pub struct OpenPut {
+    pub ticker: String,
+    pub strike_price: f64,
+    pub expiry_date: String,
+    pub open_date: String,
+    pub premium_received: f64,
+    pub fees_open: f64,
+}
+
+#[derive(Deserialize)]
+pub struct ClosePut {
+    pub action: String,
+    pub close_date: Option<String>,
+    pub close_premium: Option<f64>,
+    pub fees_close: Option<f64>,
+}
+
+pub async fn open_put(
+    State(pool): State<SqlitePool>,
+    Path(account_id): Path<i64>,
+    Json(payload): Json<OpenPut>,
+) -> Result<(StatusCode, Json<Trade>), AppError> {
+    let input = CreateTrade {
+        account_id,
+        trade_type: "PUT".to_string(),
+        ticker: payload.ticker,
+        strike_price: payload.strike_price,
+        expiry_date: payload.expiry_date,
+        open_date: payload.open_date,
+        premium_received: payload.premium_received,
+        fees_open: payload.fees_open,
+        share_lot_id: None,
+    };
+    let trade = Trade::create(&pool, &input).await?;
+    Ok((StatusCode::CREATED, Json(trade)))
+}
+
+pub async fn close_put(
+    State(pool): State<SqlitePool>,
+    Path(trade_id): Path<i64>,
+    Json(payload): Json<ClosePut>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    let trade = Trade::get(&pool, trade_id).await?;
+
+    if trade.trade_type != "PUT" {
+        return Err(AppError::BadRequest("Trade is not a PUT".to_string()));
+    }
+    if trade.status != "OPEN" {
+        return Err(AppError::BadRequest("Trade is not OPEN".to_string()));
+    }
+
+    match payload.action.as_str() {
+        "EXPIRED" => {
+            let updated = Trade::close(
+                &pool,
+                trade_id,
+                "EXPIRED",
+                None,
+                None,
+                payload.close_date,
+            )
+            .await?;
+            Ok(Json(json!(updated)))
+        }
+        "BOUGHT_BACK" => {
+            let close_premium = payload
+                .close_premium
+                .ok_or_else(|| AppError::BadRequest("close_premium required for BOUGHT_BACK".to_string()))?;
+            let updated = Trade::close(
+                &pool,
+                trade_id,
+                "BOUGHT_BACK",
+                Some(close_premium),
+                payload.fees_close,
+                payload.close_date,
+            )
+            .await?;
+            Ok(Json(json!(updated)))
+        }
+        "ASSIGNED" => {
+            let close_date = payload.close_date.unwrap_or_else(|| {
+                chrono::Local::now().format("%Y-%m-%d").to_string()
+            });
+
+            let mut tx = pool.begin().await.map_err(AppError::Database)?;
+
+            // Close the trade within the transaction
+            sqlx::query(
+                "UPDATE trades SET status = 'ASSIGNED', close_date = ?, close_premium = ?, fees_close = ? WHERE id = ?"
+            )
+            .bind(&close_date)
+            .bind(payload.close_premium)
+            .bind(payload.fees_close)
+            .bind(trade_id)
+            .execute(&mut *tx)
+            .await
+            .map_err(AppError::Database)?;
+
+            // Calculate adjusted cost basis
+            let adjusted_cb = trade.strike_price - (trade.premium_received - trade.fees_open) / 100.0;
+
+            // Create share lot within the transaction
+            let lot = sqlx::query_as::<_, ShareLot>(
+                "INSERT INTO share_lots (account_id, ticker, original_cost_basis, adjusted_cost_basis, acquisition_date, acquisition_type, source_trade_id)
+                 VALUES (?, ?, ?, ?, ?, 'ASSIGNED', ?)
+                 RETURNING id, account_id, ticker, quantity, original_cost_basis, adjusted_cost_basis, acquisition_date, acquisition_type, source_trade_id, status, created_at"
+            )
+            .bind(trade.account_id)
+            .bind(&trade.ticker)
+            .bind(trade.strike_price)
+            .bind(adjusted_cb)
+            .bind(&close_date)
+            .bind(trade_id)
+            .fetch_one(&mut *tx)
+            .await
+            .map_err(AppError::Database)?;
+
+            tx.commit().await.map_err(AppError::Database)?;
+
+            // Re-fetch the updated trade
+            let updated = Trade::get(&pool, trade_id).await?;
+
+            Ok(Json(json!({
+                "trade": updated,
+                "share_lot": lot
+            })))
+        }
+        _ => Err(AppError::BadRequest(format!("Invalid action: {}", payload.action))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::StatusCode;
+    use axum_test::TestServer;
+    use serde_json::json;
+
+    use crate::db;
+    use crate::routes::create_router;
+
+    async fn server() -> (TestServer, i64) {
+        let pool = db::init_pool("sqlite::memory:").await;
+        db::run_migrations(&pool).await;
+        let app = create_router(pool.clone());
+        let s = TestServer::new(app).unwrap();
+        let res = s
+            .post("/api/accounts")
+            .json(&json!({"name": "Test"}))
+            .await;
+        let id = res.json::<serde_json::Value>()["id"].as_i64().unwrap();
+        let s2 = TestServer::new(create_router(pool)).unwrap();
+        (s2, id)
+    }
+
+    #[tokio::test]
+    async fn test_open_put() {
+        let (server, acct_id) = server().await;
+        let res = server
+            .post(&format!("/api/accounts/{}/puts", acct_id))
+            .json(&json!({
+                "ticker": "AAPL",
+                "strike_price": 150.0,
+                "expiry_date": "2025-02-21",
+                "open_date": "2025-01-15",
+                "premium_received": 200.0,
+                "fees_open": 1.30
+            }))
+            .await;
+        res.assert_status(StatusCode::CREATED);
+        let body = res.json::<serde_json::Value>();
+        assert_eq!(body["status"], "OPEN");
+        assert_eq!(body["trade_type"], "PUT");
+    }
+
+    #[tokio::test]
+    async fn test_close_put_expired() {
+        let (server, acct_id) = server().await;
+        let create_res = server
+            .post(&format!("/api/accounts/{}/puts", acct_id))
+            .json(&json!({
+                "ticker": "AAPL",
+                "strike_price": 150.0,
+                "expiry_date": "2025-02-21",
+                "open_date": "2025-01-15",
+                "premium_received": 200.0,
+                "fees_open": 1.30
+            }))
+            .await;
+        let trade_id = create_res.json::<serde_json::Value>()["id"].as_i64().unwrap();
+
+        let res = server
+            .post(&format!("/api/trades/puts/{}/close", trade_id))
+            .json(&json!({
+                "action": "EXPIRED",
+                "close_date": "2025-02-21"
+            }))
+            .await;
+        res.assert_status(StatusCode::OK);
+        let body = res.json::<serde_json::Value>();
+        assert_eq!(body["status"], "EXPIRED");
+    }
+
+    #[tokio::test]
+    async fn test_close_put_assigned_creates_lot() {
+        let (server, acct_id) = server().await;
+        let create_res = server
+            .post(&format!("/api/accounts/{}/puts", acct_id))
+            .json(&json!({
+                "ticker": "AAPL",
+                "strike_price": 150.0,
+                "expiry_date": "2025-02-21",
+                "open_date": "2025-01-15",
+                "premium_received": 200.0,
+                "fees_open": 1.30
+            }))
+            .await;
+        let trade_id = create_res.json::<serde_json::Value>()["id"].as_i64().unwrap();
+
+        let res = server
+            .post(&format!("/api/trades/puts/{}/close", trade_id))
+            .json(&json!({
+                "action": "ASSIGNED",
+                "close_date": "2025-02-21"
+            }))
+            .await;
+        res.assert_status(StatusCode::OK);
+        let body = res.json::<serde_json::Value>();
+        assert_eq!(body["trade"]["status"], "ASSIGNED");
+
+        let lot = &body["share_lot"];
+        assert!(lot["id"].is_number());
+        // adjusted_cb = 150 - (200 - 1.30) / 100 = 150 - 1.987 = 148.013
+        let adjusted = lot["adjusted_cost_basis"].as_f64().unwrap();
+        assert!((adjusted - 148.013).abs() < 0.001);
+    }
+}

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -1,12 +1,17 @@
-use axum::{routing::{delete, get}, Router};
+use axum::{routing::{delete, get, post}, Router};
 use sqlx::SqlitePool;
 use tower_http::cors::CorsLayer;
-use crate::handlers::accounts;
+use crate::handlers::{accounts, calls, puts};
 
 pub fn create_router(pool: SqlitePool) -> Router {
     Router::new()
         .route("/api/accounts", get(accounts::list_accounts).post(accounts::create_account))
         .route("/api/accounts/:id", delete(accounts::delete_account))
+        .route("/api/accounts/:id/puts", post(puts::open_put))
+        .route("/api/trades/puts/:id/close", post(puts::close_put))
+        .route("/api/accounts/:id/calls", post(calls::open_call))
+        .route("/api/accounts/:id/share-lots", get(calls::list_share_lots))
+        .route("/api/trades/calls/:id/close", post(calls::close_call))
         .layer(CorsLayer::permissive())
         .with_state(pool)
 }


### PR DESCRIPTION
## Summary
- Add PUT trade open/close handlers with EXPIRED, BOUGHT_BACK, and ASSIGNED flows
- Add CALL trade open/close handlers with EXPIRED, BOUGHT_BACK, and CALLED_AWAY flows
- Add share lots listing endpoint (`GET /api/accounts/:id/share-lots`)
- ASSIGNED flow uses a transaction to atomically close the PUT and create a ShareLot with adjusted cost basis
- CALLED_AWAY flow reduces cost basis and marks the lot as called away
- 6 new integration tests (3 PUT + 3 CALL), all passing (14 total)

## Test plan
- [x] `cargo test puts` — 3 tests pass (open, expire, assign with lot creation)
- [x] `cargo test calls` — 3 tests pass (open on lot, expire reduces cost basis, called away marks lot)
- [x] Full `cargo test` — all 14 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)