### PR TITLE
feat: manual share lot entry API

### DIFF
--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -1,3 +1,4 @@
 pub mod accounts;
 pub mod calls;
 pub mod puts;
+pub mod share_lots;

--- a/backend/src/handlers/share_lots.rs
+++ b/backend/src/handlers/share_lots.rs
@@ -1,0 +1,60 @@
+use axum::{extract::{Path, State}, http::StatusCode, Json};
+use serde::Deserialize;
+use sqlx::SqlitePool;
+use crate::errors::AppError;
+use crate::models::share_lot::{CreateShareLot, ShareLot};
+
+#[derive(Deserialize)]
+pub struct CreateManualLot {
+    pub ticker: String,
+    pub cost_basis: f64,
+    pub acquisition_date: String,
+}
+
+pub async fn create_manual_lot(
+    State(pool): State<SqlitePool>,
+    Path(account_id): Path<i64>,
+    Json(payload): Json<CreateManualLot>,
+) -> Result<(StatusCode, Json<ShareLot>), AppError> {
+    if payload.cost_basis <= 0.0 {
+        return Err(AppError::BadRequest("cost_basis must be positive".to_string()));
+    }
+    let lot = ShareLot::create(&pool, &CreateShareLot {
+        account_id,
+        ticker: payload.ticker.to_uppercase(),
+        original_cost_basis: payload.cost_basis,
+        adjusted_cost_basis: None,
+        acquisition_date: payload.acquisition_date,
+        acquisition_type: "MANUAL".to_string(),
+        source_trade_id: None,
+    }).await?;
+    Ok((StatusCode::CREATED, Json(lot)))
+}
+
+#[cfg(test)]
+mod tests {
+    use axum_test::TestServer;
+    use axum::http::StatusCode;
+    use serde_json::json;
+    use crate::{db, routes::create_router};
+
+    #[tokio::test]
+    async fn test_create_manual_lot() {
+        let pool = db::init_pool("sqlite::memory:").await;
+        db::run_migrations(&pool).await;
+        let srv = TestServer::new(create_router(pool)).unwrap();
+        let acct_id = srv.post("/api/accounts").json(&json!({"name":"T"})).await
+            .json::<serde_json::Value>()["id"].as_i64().unwrap();
+        let res = srv.post(&format!("/api/accounts/{}/share-lots", acct_id))
+            .json(&json!({
+                "ticker": "MSFT",
+                "cost_basis": 300.00,
+                "acquisition_date": "2024-06-01"
+            })).await;
+        res.assert_status(StatusCode::CREATED);
+        let body = res.json::<serde_json::Value>();
+        assert_eq!(body["ticker"], "MSFT");
+        assert_eq!(body["acquisition_type"], "MANUAL");
+        assert_eq!(body["adjusted_cost_basis"].as_f64().unwrap(), 300.00);
+    }
+}

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -1,7 +1,7 @@
 use axum::{routing::{delete, get, post}, Router};
 use sqlx::SqlitePool;
 use tower_http::cors::CorsLayer;
-use crate::handlers::{accounts, calls, puts};
+use crate::handlers::{accounts, calls, puts, share_lots};
 
 pub fn create_router(pool: SqlitePool) -> Router {
     Router::new()
@@ -10,7 +10,7 @@ pub fn create_router(pool: SqlitePool) -> Router {
         .route("/api/accounts/:id/puts", post(puts::open_put))
         .route("/api/trades/puts/:id/close", post(puts::close_put))
         .route("/api/accounts/:id/calls", post(calls::open_call))
-        .route("/api/accounts/:id/share-lots", get(calls::list_share_lots))
+        .route("/api/accounts/:id/share-lots", get(calls::list_share_lots).post(share_lots::create_manual_lot))
         .route("/api/trades/calls/:id/close", post(calls::close_call))
         .layer(CorsLayer::permissive())
         .with_state(pool)


### PR DESCRIPTION
## Summary
- Add `POST /api/accounts/:id/share-lots` endpoint for manually adding share lots (shares already held before using the app)
- Validates cost_basis > 0, sets acquisition_type to MANUAL
- Combined with existing GET route for listing active share lots
- Frontend form deferred to PR 8 (depends on frontend foundation)

## Test plan
- [x] `cargo test manual_lot` — test passes (creates lot, verifies ticker/type/cost_basis)
- [x] Full `cargo test` — all 15 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)