### PR TITLE
feat: agentic issue processor with Claude Code

### DIFF
--- a/scripts/issue-prompt-template.md
+++ b/scripts/issue-prompt-template.md
@@ -1,0 +1,40 @@
+# Issue #{number}: {title}
+
+**Labels**: {labels}
+**Type**: {issue_type}
+
+## Description
+
+{body}
+
+## Instructions
+
+You are an autonomous agent working on the Options Wheel Tracker project.
+Read CLAUDE.md at the project root for architecture, conventions, and rules.
+
+### Your workflow
+
+1. **Understand the issue** — read the description carefully. Read relevant source files before changing anything.
+2. **Create a branch** — `{branch_name}` (already created for you, you are on it).
+3. **Implement the fix or feature** with minimal, focused changes.
+4. **Write tests** — regression test for bugs, feature tests for new model/handler logic.
+5. **Verify your work**:
+   - If you changed backend code: run `cargo check` and `cargo test` in `backend/`
+   - If you changed frontend code: run `npm run build` in `frontend/`
+   - If you changed migrations: run `scripts/test-migration.sh`
+6. **Commit your changes** with a descriptive message referencing the issue.
+7. **Push the branch** and **open a PR** targeting `dev` with `Closes #{number}` in the body.
+
+### Constraints
+
+- Do NOT modify more than 5 files unless the issue explicitly requires it.
+- Do NOT delete any existing files.
+- Do NOT install new dependencies (modify Cargo.toml or package.json) unless the issue explicitly requests it.
+- Do NOT modify: Makefile, .env*, next.config.ts, .claude/ settings files.
+- If the change requires more than ~200 lines of new code, stop and comment on the issue asking for guidance.
+- If you are unsure about the approach or need clarification, comment on the issue explaining what you need, then stop.
+
+### On failure
+
+- If tests fail after 2 fix attempts, stop and comment the error output on the issue.
+- If you cannot understand or reproduce the issue, comment on the issue explaining what you found.

--- a/scripts/process_issues.py
+++ b/scripts/process_issues.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+"""
+Agentic issue processor for the Options Wheel Tracker.
+
+Polls GitHub for issues labeled 'todo', picks the oldest one, and spawns
+Claude Code in headless mode to implement the fix or feature. Each issue
+gets its own git worktree for isolation.
+
+Label state machine:
+    todo                → agent picks it up, moves to in-progress
+    in-progress         → agent is working (skipped on next poll)
+    pr-ready            → agent finished, PR is open for review
+    needs-attention     → agent failed or hit a constraint
+    needs-clarification → agent commented a question, waiting for human
+    manual              → 3 failures, needs human intervention
+
+Usage:
+    python3 scripts/process_issues.py [--dry-run] [--issue NUMBER]
+
+Options:
+    --dry-run       Show what would happen without executing
+    --issue NUMBER  Process a specific issue by number (skips polling)
+"""
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# --- Configuration ---
+
+# Repository info (extracted from git remote)
+REPO = None  # Set dynamically from git remote
+
+# Paths
+REPO_ROOT = Path(__file__).resolve().parent.parent  # /root/options_wheel_tracker/dev
+WORKTREE_BASE = REPO_ROOT.parent / "worktrees"  # /root/options_wheel_tracker/worktrees
+PROMPT_TEMPLATE = REPO_ROOT / "scripts" / "issue-prompt-template.md"
+LOG_DIR = REPO_ROOT.parent / "logs"
+
+# Agent constraints
+MAX_TIMEOUT_SECONDS = 600  # 10 minutes
+MAX_RETRIES = 3
+MAX_BUDGET_USD = 5.0  # Maximum API spend per issue
+
+
+def run(cmd: list[str], cwd: str | None = None, check: bool = True,
+        capture: bool = True, timeout: int | None = None) -> subprocess.CompletedProcess:
+    """Run a subprocess command and return the result."""
+    result = subprocess.run(
+        cmd, cwd=cwd, capture_output=capture, text=True,
+        timeout=timeout, check=False
+    )
+    if check and result.returncode != 0:
+        stderr = result.stderr.strip() if result.stderr else ""
+        raise RuntimeError(f"Command failed: {' '.join(cmd)}\n{stderr}")
+    return result
+
+
+def get_repo_name() -> str:
+    """Extract owner/repo from git remote URL."""
+    result = run(["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+                 cwd=str(REPO_ROOT))
+    return result.stdout.strip()
+
+
+def log(msg: str):
+    """Print a timestamped log message."""
+    ts = time.strftime("%Y-%m-%d %H:%M:%S")
+    print(f"[{ts}] {msg}")
+
+
+def gh_api(endpoint: str, method: str = "GET", data: dict | None = None,
+           cwd: str | None = None) -> dict | list | None:
+    """Call GitHub API via gh CLI."""
+    cmd = ["gh", "api", endpoint]
+    if method != "GET":
+        cmd.extend(["--method", method])
+    if data:
+        for key, value in data.items():
+            cmd.extend(["-f", f"{key}={value}"])
+    result = run(cmd, cwd=cwd or str(REPO_ROOT), check=False)
+    if result.returncode != 0:
+        log(f"  gh api error: {result.stderr.strip()}")
+        return None
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def fetch_todo_issues() -> list[dict]:
+    """Fetch open issues labeled 'todo', oldest first."""
+    result = run([
+        "gh", "issue", "list",
+        "--label", "todo",
+        "--state", "open",
+        "--search", "sort:created-asc",
+        "--json", "number,title,body,labels,createdAt",
+        "--limit", "10"
+    ], cwd=str(REPO_ROOT))
+    issues = json.loads(result.stdout)
+    return issues
+
+
+def fetch_issue(number: int) -> dict | None:
+    """Fetch a specific issue by number."""
+    result = run([
+        "gh", "issue", "view", str(number),
+        "--json", "number,title,body,labels,createdAt,state"
+    ], cwd=str(REPO_ROOT), check=False)
+    if result.returncode != 0:
+        return None
+    return json.loads(result.stdout)
+
+
+def is_in_progress() -> bool:
+    """Check if any issue is currently in-progress."""
+    result = run([
+        "gh", "issue", "list",
+        "--label", "in-progress",
+        "--state", "open",
+        "--json", "number",
+        "--limit", "1"
+    ], cwd=str(REPO_ROOT))
+    issues = json.loads(result.stdout)
+    return len(issues) > 0
+
+
+def set_label(issue_number: int, add: str, remove: str | None = None):
+    """Add a label and optionally remove another."""
+    if remove:
+        run(["gh", "issue", "edit", str(issue_number),
+             "--remove-label", remove, "--add-label", add],
+            cwd=str(REPO_ROOT))
+    else:
+        run(["gh", "issue", "edit", str(issue_number),
+             "--add-label", add],
+            cwd=str(REPO_ROOT))
+
+
+def comment_on_issue(issue_number: int, body: str):
+    """Post a comment on the issue."""
+    run(["gh", "issue", "comment", str(issue_number), "--body", body],
+        cwd=str(REPO_ROOT))
+
+
+def get_retry_count(issue_number: int) -> int:
+    """Count how many times we've attempted this issue (by counting in-progress label additions)."""
+    # Check for a retry marker in issue comments
+    result = run([
+        "gh", "issue", "view", str(issue_number),
+        "--json", "comments",
+        "-q", '.comments[] | select(.body | startswith("[agent-retry]")) | .body'
+    ], cwd=str(REPO_ROOT), check=False)
+    if result.returncode != 0:
+        return 0
+    return result.stdout.strip().count("[agent-retry]")
+
+
+def slugify(text: str) -> str:
+    """Convert issue title to branch-name-safe slug."""
+    slug = text.lower()
+    slug = re.sub(r'[^a-z0-9\s-]', '', slug)
+    slug = re.sub(r'[\s]+', '-', slug)
+    slug = slug.strip('-')[:40]
+    return slug
+
+
+def determine_issue_type(issue: dict) -> str:
+    """Determine if issue is a bug or feature from labels."""
+    label_names = [l["name"] for l in issue.get("labels", [])]
+    if "bug" in label_names:
+        return "bug"
+    if "feature" in label_names or "enhancement" in label_names:
+        return "feature"
+    # Guess from title
+    title = issue["title"].lower()
+    if any(w in title for w in ["fix", "bug", "error", "crash", "broken", "wrong"]):
+        return "bug"
+    return "feature"
+
+
+def build_prompt(issue: dict, branch_name: str) -> str:
+    """Build the agent prompt from the template and issue data."""
+    template = PROMPT_TEMPLATE.read_text()
+    label_names = ", ".join(l["name"] for l in issue.get("labels", []))
+    issue_type = determine_issue_type(issue)
+
+    prompt = template.format(
+        number=issue["number"],
+        title=issue["title"],
+        labels=label_names,
+        issue_type=issue_type,
+        body=issue.get("body", "(no description)") or "(no description)",
+        branch_name=branch_name,
+    )
+    return prompt
+
+
+def create_worktree(issue_number: int, branch_name: str) -> Path:
+    """Create an isolated git worktree for this issue."""
+    worktree_path = WORKTREE_BASE / f"issue-{issue_number}"
+
+    # Clean up if leftover from a previous attempt
+    if worktree_path.exists():
+        log(f"  Cleaning up stale worktree at {worktree_path}")
+        run(["git", "worktree", "remove", "--force", str(worktree_path)],
+            cwd=str(REPO_ROOT), check=False)
+        if worktree_path.exists():
+            shutil.rmtree(worktree_path)
+
+    WORKTREE_BASE.mkdir(parents=True, exist_ok=True)
+
+    # Fetch latest dev
+    run(["git", "fetch", "origin", "dev"], cwd=str(REPO_ROOT))
+
+    # Create the branch from dev and set up the worktree
+    # First, try to delete the branch if it exists from a previous attempt
+    run(["git", "branch", "-D", branch_name], cwd=str(REPO_ROOT), check=False)
+
+    run(["git", "worktree", "add", "-b", branch_name,
+         str(worktree_path), "origin/dev"],
+        cwd=str(REPO_ROOT))
+
+    # Install frontend dependencies if node_modules doesn't exist
+    frontend_nm = worktree_path / "frontend" / "node_modules"
+    if not frontend_nm.exists():
+        log("  Installing frontend dependencies in worktree...")
+        run(["npm", "install"], cwd=str(worktree_path / "frontend"), check=False)
+
+    return worktree_path
+
+
+def cleanup_worktree(issue_number: int):
+    """Remove the worktree after processing."""
+    worktree_path = WORKTREE_BASE / f"issue-{issue_number}"
+    if worktree_path.exists():
+        run(["git", "worktree", "remove", "--force", str(worktree_path)],
+            cwd=str(REPO_ROOT), check=False)
+
+
+def run_agent(worktree_path: Path, prompt: str) -> tuple[bool, str]:
+    """Run Claude Code in headless mode. Returns (success, output)."""
+    cmd = [
+        "claude", "-p",
+        "--permission-mode", "auto",
+        "--max-budget-usd", str(MAX_BUDGET_USD),
+        prompt
+    ]
+
+    log("  Running Claude Code agent...")
+    result = run(
+        cmd,
+        cwd=str(worktree_path),
+        check=False,
+        timeout=MAX_TIMEOUT_SECONDS
+    )
+
+    output = result.stdout or ""
+    if result.stderr:
+        output += "\n" + result.stderr
+
+    success = result.returncode == 0
+    return success, output
+
+
+def check_pr_created(issue_number: int) -> bool:
+    """Check if a PR was created that references this issue."""
+    result = run([
+        "gh", "pr", "list",
+        "--state", "open",
+        "--search", f"issue {issue_number}",
+        "--json", "number",
+        "--limit", "5"
+    ], cwd=str(REPO_ROOT), check=False)
+    if result.returncode != 0:
+        return False
+    prs = json.loads(result.stdout)
+    return len(prs) > 0
+
+
+def save_log(issue_number: int, output: str):
+    """Save agent output to a log file."""
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    ts = time.strftime("%Y%m%d-%H%M%S")
+    log_file = LOG_DIR / f"issue-{issue_number}-{ts}.log"
+    log_file.write_text(output)
+    log(f"  Agent output saved to {log_file}")
+
+
+def process_issue(issue: dict, dry_run: bool = False):
+    """Process a single issue end-to-end."""
+    number = issue["number"]
+    title = issue["title"]
+    issue_type = determine_issue_type(issue)
+    prefix = "fix" if issue_type == "bug" else "feat"
+    slug = slugify(title)
+    branch_name = f"{prefix}/issue-{number}-{slug}"
+
+    log(f"Processing issue #{number}: {title}")
+    log(f"  Type: {issue_type}, Branch: {branch_name}")
+
+    if dry_run:
+        log("  [DRY RUN] Would process this issue. Skipping.")
+        return
+
+    # Check retry count
+    retries = get_retry_count(number)
+    if retries >= MAX_RETRIES:
+        log(f"  Issue has {retries} retries — marking as manual")
+        set_label(number, "manual", "todo")
+        comment_on_issue(number,
+            f"This issue has failed {retries} times. Marking as `manual` for human intervention.")
+        return
+
+    # Mark in-progress
+    set_label(number, "in-progress", "todo")
+
+    # Create worktree
+    try:
+        worktree_path = create_worktree(number, branch_name)
+    except Exception as e:
+        log(f"  Failed to create worktree: {e}")
+        set_label(number, "needs-attention", "in-progress")
+        comment_on_issue(number, f"[agent-retry] Failed to set up worktree:\n```\n{e}\n```")
+        return
+
+    # Build prompt and run agent
+    prompt = build_prompt(issue, branch_name)
+    try:
+        success, output = run_agent(worktree_path, prompt)
+    except subprocess.TimeoutExpired:
+        log(f"  Agent timed out after {MAX_TIMEOUT_SECONDS}s")
+        success = False
+        output = f"Agent timed out after {MAX_TIMEOUT_SECONDS} seconds"
+
+    save_log(number, output)
+
+    # Determine outcome
+    if success and check_pr_created(number):
+        log(f"  Success — PR created for issue #{number}")
+        set_label(number, "pr-ready", "in-progress")
+    elif success:
+        # Agent exited cleanly but no PR — might have commented a question
+        log(f"  Agent finished but no PR found — checking for clarification")
+        # Check if agent left a comment asking for clarification
+        if "clarification" in output.lower() or "unsure" in output.lower():
+            set_label(number, "needs-clarification", "in-progress")
+        else:
+            set_label(number, "needs-attention", "in-progress")
+            comment_on_issue(number,
+                f"[agent-retry] Agent completed but did not create a PR. "
+                f"Check the logs for details.")
+    else:
+        log(f"  Agent failed for issue #{number}")
+        retries += 1
+        if retries >= MAX_RETRIES:
+            set_label(number, "manual", "in-progress")
+            # Truncate output for the comment (GitHub has a 65536 char limit)
+            truncated = output[-3000:] if len(output) > 3000 else output
+            comment_on_issue(number,
+                f"[agent-retry] Failed {retries}/{MAX_RETRIES} times — marking as `manual`.\n\n"
+                f"Last output:\n```\n{truncated}\n```")
+        else:
+            set_label(number, "todo", "in-progress")
+            comment_on_issue(number,
+                f"[agent-retry] Attempt {retries}/{MAX_RETRIES} failed. "
+                f"Will retry on next poll.")
+
+    # Cleanup worktree (keep the branch for PR)
+    cleanup_worktree(number)
+
+
+def ensure_labels_exist():
+    """Create required labels if they don't exist on the repo."""
+    required = {
+        "todo": "0E8A16",
+        "in-progress": "FBCA04",
+        "pr-ready": "1D76DB",
+        "needs-attention": "D93F0B",
+        "needs-clarification": "F9D0C4",
+        "manual": "B60205",
+    }
+    result = run(["gh", "label", "list", "--json", "name", "--limit", "100"],
+                 cwd=str(REPO_ROOT))
+    existing = {l["name"] for l in json.loads(result.stdout)}
+
+    for name, color in required.items():
+        if name not in existing:
+            log(f"  Creating label: {name}")
+            run(["gh", "label", "create", name, "--color", color,
+                 "--description", f"Agent workflow: {name}"],
+                cwd=str(REPO_ROOT))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Process GitHub issues with Claude Code agent")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Show what would happen without executing")
+    parser.add_argument("--issue", type=int,
+                        help="Process a specific issue by number")
+    args = parser.parse_args()
+
+    global REPO
+    REPO = get_repo_name()
+    log(f"Repository: {REPO}")
+
+    # Ensure labels exist
+    ensure_labels_exist()
+
+    if args.issue:
+        # Process a specific issue
+        issue = fetch_issue(args.issue)
+        if not issue:
+            log(f"Issue #{args.issue} not found")
+            sys.exit(1)
+        if issue["state"] != "OPEN":
+            log(f"Issue #{args.issue} is not open (state: {issue['state']})")
+            sys.exit(1)
+        process_issue(issue, dry_run=args.dry_run)
+        return
+
+    # Poll mode: check for in-progress first
+    if is_in_progress():
+        log("An issue is already in-progress — skipping this run")
+        return
+
+    # Fetch todo issues
+    issues = fetch_todo_issues()
+    if not issues:
+        log("No issues labeled 'todo' — nothing to do")
+        return
+
+    log(f"Found {len(issues)} todo issue(s)")
+
+    # Process the oldest one
+    process_issue(issues[0], dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup-cron.sh
+++ b/scripts/setup-cron.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Set up the cron job for automatic issue processing.
+# Runs every 30 minutes, logs output to /root/options_wheel_tracker/logs/cron.log
+#
+# Usage: bash scripts/setup-cron.sh [install|remove|status]
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+LOG_DIR="$(dirname "$REPO_ROOT")/logs"
+CRON_CMD="cd $REPO_ROOT && /usr/bin/python3 scripts/process_issues.py >> $LOG_DIR/cron.log 2>&1"
+CRON_ENTRY="*/30 * * * * $CRON_CMD"
+CRON_MARKER="process_issues.py"
+
+mkdir -p "$LOG_DIR"
+
+case "${1:-status}" in
+    install)
+        # Remove existing entry if present, then add
+        (crontab -l 2>/dev/null | grep -v "$CRON_MARKER"; echo "$CRON_ENTRY") | crontab -
+        echo "Cron job installed: runs every 30 minutes"
+        echo "  Logs: $LOG_DIR/cron.log"
+        echo "  Agent logs: $LOG_DIR/issue-*.log"
+        crontab -l | grep "$CRON_MARKER"
+        ;;
+    remove)
+        crontab -l 2>/dev/null | grep -v "$CRON_MARKER" | crontab -
+        echo "Cron job removed"
+        ;;
+    status)
+        if crontab -l 2>/dev/null | grep -q "$CRON_MARKER"; then
+            echo "Cron job is ACTIVE:"
+            crontab -l | grep "$CRON_MARKER"
+        else
+            echo "Cron job is NOT installed"
+            echo "Run: bash scripts/setup-cron.sh install"
+        fi
+        ;;
+    *)
+        echo "Usage: $0 [install|remove|status]"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary

- **`scripts/process_issues.py`** — Polls GitHub for `todo`-labeled issues, spawns Claude Code in headless mode (`claude -p`) to implement each one in an isolated git worktree
- **`scripts/issue-prompt-template.md`** — Prompt template with constraints (max 5 files, max ~200 lines, no dependency changes, mandatory tests)
- **`scripts/setup-cron.sh`** — Helper to install/remove/check the cron job (every 30 minutes)

### Label state machine
```
todo → in-progress → pr-ready        (success: PR created)
                   → needs-attention  (agent finished but no PR)
                   → needs-clarification (agent asked a question)
                   → todo             (retry, up to 3 attempts)
                   → manual           (3 failures, needs human)
```

### Guardrails
- 10-minute timeout per issue
- $5 max API budget per issue
- Isolated git worktree per issue
- 3-strike retry with automatic `manual` label
- Agent opens PRs but never merges

## Test plan
- [x] `python3 scripts/process_issues.py --dry-run` works
- [x] `python3 scripts/process_issues.py --dry-run --issue 12` works
- [x] Labels auto-created on first run
- [x] Full end-to-end: label an issue `todo` and run without `--dry-run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)