### PR TITLE
feat: add close trade buttons to dashboard

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { MetricCard } from '@/components/dashboard/MetricCard';
 import { ActivePositions } from '@/components/dashboard/ActivePositions';
 import { api } from '@/lib/api';
@@ -11,9 +11,13 @@ export default function DashboardPage() {
   const { selectedAccountId } = useAccounts();
   const [data, setData] = useState<DashboardData | null>(null);
 
-  useEffect(() => {
+  const refreshDashboard = useCallback(() => {
     api.dashboard(selectedAccountId ?? undefined).then(setData);
   }, [selectedAccountId]);
+
+  useEffect(() => {
+    refreshDashboard();
+  }, [refreshDashboard]);
 
   if (!data) return <div className="text-muted-foreground">Loading...</div>;
 
@@ -26,7 +30,7 @@ export default function DashboardPage() {
         <MetricCard title="Realized Yield (Ann.)" value={formatPercent(data.realized_annualized_yield)} subtitle="Closed trades" />
         <MetricCard title="Open Yield (Ann.)" value={formatPercent(data.open_annualized_yield)} subtitle="Current open trades" />
       </div>
-      <ActivePositions openTrades={data.open_trades} activeLots={data.active_share_lots} />
+      <ActivePositions openTrades={data.open_trades} activeLots={data.active_share_lots} onTradeClose={refreshDashboard} />
     </div>
   );
 }

--- a/frontend/src/components/dashboard/ActivePositions.tsx
+++ b/frontend/src/components/dashboard/ActivePositions.tsx
@@ -2,14 +2,17 @@
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
 import { formatCurrency, daysToExpiry } from '@/lib/utils';
+import { ClosePutModal } from '@/components/trades/ClosePutModal';
+import { CloseCallModal } from '@/components/trades/CloseCallModal';
 import type { ShareLot, Trade } from '@/lib/types';
 
 interface Props {
   openTrades: Trade[];
   activeLots: ShareLot[];
+  onTradeClose?: () => void;
 }
 
-export function ActivePositions({ openTrades, activeLots }: Props) {
+export function ActivePositions({ openTrades, activeLots, onTradeClose }: Props) {
   return (
     <div className="space-y-6">
       <div>
@@ -23,11 +26,12 @@ export function ActivePositions({ openTrades, activeLots }: Props) {
               <TableHead>Expiry</TableHead>
               <TableHead>DTE</TableHead>
               <TableHead>Premium</TableHead>
+              <TableHead></TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             {openTrades.length === 0 && (
-              <TableRow><TableCell colSpan={6} className="text-center text-muted-foreground">No open trades</TableCell></TableRow>
+              <TableRow><TableCell colSpan={7} className="text-center text-muted-foreground">No open trades</TableCell></TableRow>
             )}
             {openTrades.map((t) => (
               <TableRow key={t.id}>
@@ -37,6 +41,12 @@ export function ActivePositions({ openTrades, activeLots }: Props) {
                 <TableCell>{t.expiry_date}</TableCell>
                 <TableCell>{daysToExpiry(t.expiry_date)}d</TableCell>
                 <TableCell>{formatCurrency(t.premium_received)}</TableCell>
+                <TableCell>
+                  {t.trade_type === 'PUT'
+                    ? <ClosePutModal tradeId={t.id} onClose={onTradeClose ?? (() => {})} />
+                    : <CloseCallModal tradeId={t.id} onClose={onTradeClose ?? (() => {})} />
+                  }
+                </TableCell>
               </TableRow>
             ))}
           </TableBody>

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -26,7 +26,8 @@ fi
 FRONTEND_CHANGED=$(echo "$STAGED" | grep '^frontend/src/.*\.\(ts\|tsx\|js\|jsx\)$' || true)
 if [ -n "$FRONTEND_CHANGED" ]; then
     echo "[pre-commit] Running ESLint on frontend..."
-    (cd "$REPO_ROOT/frontend" && npx eslint --max-warnings 0 $FRONTEND_CHANGED 2>&1) || {
+    FRONTEND_FILES=$(echo "$FRONTEND_CHANGED" | sed 's|^frontend/||')
+    (cd "$REPO_ROOT/frontend" && npx eslint --max-warnings 0 $FRONTEND_FILES 2>&1) || {
         echo ""
         echo "ERROR: ESLint check failed. Fix the errors above, then re-stage and commit."
         exit 1


### PR DESCRIPTION
## Summary
- Wire existing `ClosePutModal` and `CloseCallModal` components into the dashboard's Open Trades table, adding a "Close" button to each row
- Dashboard auto-refreshes metrics and positions after a trade is closed
- Fix pre-commit hook ESLint path bug for git worktrees (strip `frontend/` prefix)

Closes #12

## Test plan
- [x] Open dashboard with open PUT trades — verify "Close" button appears
- [x] Click Close on a PUT → modal shows EXPIRED / BOUGHT_BACK / ASSIGNED options
- [x] Click Close on a CALL → modal shows EXPIRED / BOUGHT_BACK / CALLED_AWAY options
- [x] Close a trade → dashboard metrics and open trades list refresh automatically
- [x] Verify `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)