### PR TITLE
feat: support quantity for contracts in trade forms and tables

### DIFF
--- a/frontend/src/components/dashboard/ActivePositions.tsx
+++ b/frontend/src/components/dashboard/ActivePositions.tsx
@@ -22,6 +22,7 @@ export function ActivePositions({ openTrades, activeLots, onTradeClose }: Props)
             <TableRow>
               <TableHead>Ticker</TableHead>
               <TableHead>Type</TableHead>
+              <TableHead>Qty</TableHead>
               <TableHead>Strike</TableHead>
               <TableHead>Expiry</TableHead>
               <TableHead>DTE</TableHead>
@@ -31,12 +32,13 @@ export function ActivePositions({ openTrades, activeLots, onTradeClose }: Props)
           </TableHeader>
           <TableBody>
             {openTrades.length === 0 && (
-              <TableRow><TableCell colSpan={7} className="text-center text-muted-foreground">No open trades</TableCell></TableRow>
+              <TableRow><TableCell colSpan={8} className="text-center text-muted-foreground">No open trades</TableCell></TableRow>
             )}
             {openTrades.map((t) => (
               <TableRow key={t.id}>
                 <TableCell className="font-medium">{t.ticker}</TableCell>
                 <TableCell><Badge variant={t.trade_type === 'PUT' ? 'secondary' : 'default'}>{t.trade_type}</Badge></TableCell>
+                <TableCell>{t.quantity}</TableCell>
                 <TableCell>{formatCurrency(t.strike_price)}</TableCell>
                 <TableCell>{t.expiry_date}</TableCell>
                 <TableCell>{daysToExpiry(t.expiry_date)}d</TableCell>

--- a/frontend/src/components/history/TradeTable.tsx
+++ b/frontend/src/components/history/TradeTable.tsx
@@ -21,6 +21,7 @@ export function TradeTable({ trades }: Props) {
         <TableRow>
           <TableHead>Ticker</TableHead>
           <TableHead>Type</TableHead>
+          <TableHead>Qty</TableHead>
           <TableHead>Strike</TableHead>
           <TableHead>Open Date</TableHead>
           <TableHead>Close Date</TableHead>
@@ -31,12 +32,13 @@ export function TradeTable({ trades }: Props) {
       </TableHeader>
       <TableBody>
         {trades.length === 0 && (
-          <TableRow><TableCell colSpan={8} className="text-center text-muted-foreground">No trades found</TableCell></TableRow>
+          <TableRow><TableCell colSpan={9} className="text-center text-muted-foreground">No trades found</TableCell></TableRow>
         )}
         {trades.map((t) => (
           <TableRow key={t.id}>
             <TableCell className="font-medium">{t.ticker}</TableCell>
             <TableCell><Badge variant={t.trade_type === 'PUT' ? 'secondary' : 'default'}>{t.trade_type}</Badge></TableCell>
+            <TableCell>{t.quantity}</TableCell>
             <TableCell>{formatCurrency(t.strike_price)}</TableCell>
             <TableCell>{t.open_date}</TableCell>
             <TableCell>{t.close_date ?? '—'}</TableCell>

--- a/frontend/src/components/trades/CallForm.tsx
+++ b/frontend/src/components/trades/CallForm.tsx
@@ -19,7 +19,7 @@ export function CallForm() {
   const [form, setForm] = useState({
     ticker: '', strike_price: '', expiry_date: '',
     open_date: new Date().toISOString().split('T')[0],
-    premium_received: '', fees_open: '1.30',
+    premium_received: '', fees_open: '1.30', quantity: '1',
   });
   const [error, setError] = useState('');
 
@@ -57,6 +57,7 @@ export function CallForm() {
         strike_price: parseFloat(form.strike_price),
         premium_received: parseFloat(form.premium_received),
         fees_open: parseFloat(form.fees_open),
+        quantity: parseInt(form.quantity),
       });
       router.push('/');
     } catch (err: unknown) {
@@ -103,6 +104,7 @@ export function CallForm() {
             { label: 'Open Date', key: 'open_date', placeholder: '', type: 'date' },
             { label: 'Premium Received ($)', key: 'premium_received', placeholder: '150.00', type: 'number' },
             { label: 'Fees ($)', key: 'fees_open', placeholder: '1.30', type: 'number' },
+            { label: 'Quantity (contracts)', key: 'quantity', placeholder: '1', type: 'number' },
           ].map(({ label, key, placeholder, type }) => (
             <div key={key} className="space-y-1">
               <Label>{label}</Label>

--- a/frontend/src/components/trades/PutForm.tsx
+++ b/frontend/src/components/trades/PutForm.tsx
@@ -14,7 +14,7 @@ export function PutForm() {
   const [form, setForm] = useState({
     ticker: '', strike_price: '', expiry_date: '',
     open_date: new Date().toISOString().split('T')[0],
-    premium_received: '', fees_open: '1.30',
+    premium_received: '', fees_open: '1.30', quantity: '1',
   });
   const [error, setError] = useState('');
 
@@ -31,6 +31,7 @@ export function PutForm() {
         strike_price: parseFloat(form.strike_price),
         premium_received: parseFloat(form.premium_received),
         fees_open: parseFloat(form.fees_open),
+        quantity: parseInt(form.quantity),
       });
       router.push('/');
     } catch (err: unknown) {
@@ -50,6 +51,7 @@ export function PutForm() {
             { label: 'Open Date', key: 'open_date', placeholder: '', type: 'date' },
             { label: 'Premium Received ($)', key: 'premium_received', placeholder: '200.00', type: 'number' },
             { label: 'Fees ($)', key: 'fees_open', placeholder: '1.30', type: 'number' },
+            { label: 'Quantity (contracts)', key: 'quantity', placeholder: '1', type: 'number' },
           ].map(({ label, key, placeholder, type }) => (
             <div key={key} className="space-y-1">
               <Label>{label}</Label>


### PR DESCRIPTION
## Summary
- Added a **Quantity (contracts)** input field to both the PUT and CALL trade forms, defaulting to 1
- Added a **Qty** column to the dashboard open trades table and the history trade table

Closes #16

## Test plan
- [ ] Open a PUT trade with quantity > 1, verify it saves correctly
- [ ] Open a CALL trade with quantity > 1, verify it saves correctly
- [ ] Verify the dashboard open trades table shows the Qty column
- [ ] Verify the history tab shows the Qty column
- [ ] Verify default quantity of 1 still works when not changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)