### PR TITLE
fix: show complete lot details in call page lot selector

### DIFF
--- a/frontend/src/components/trades/CallForm.tsx
+++ b/frontend/src/components/trades/CallForm.tsx
@@ -79,7 +79,11 @@ export function CallForm() {
             ) : (
               <Select value={selectedLotId || null} onValueChange={handleLotChange}>
                 <SelectTrigger>
-                  <SelectValue placeholder="Select lot" />
+                  <SelectValue placeholder="Select lot">
+                    {selectedLot
+                      ? `${selectedLot.ticker} — ${selectedLot.quantity} shares @ ${formatCurrency(selectedLot.adjusted_cost_basis)} adj. CB`
+                      : undefined}
+                  </SelectValue>
                 </SelectTrigger>
                 <SelectContent>
                   {lots.map((l) => (


### PR DESCRIPTION
## Summary
- Fixed the Share Lot selector on `/trades/new-call` showing incomplete lot details (missing cost basis after `$`)
- base-ui's `SelectValue` renders the raw `value` prop (lot ID number) by default — now passes explicit children to display the full `TICKER — N shares @ $X.XX adj. CB` text when a lot is selected

Closes #17

## Test plan
- [x] Navigate to `/trades/new-call`, select an account with active share lots
- [x] Verify the lot dropdown items show full details: ticker, quantity, and adjusted cost basis
- [x] Select a lot and verify the trigger displays the complete lot description (not just a number)

🤖 Generated with [Claude Code](https://claude.com/claude-code)