### PR TITLE
feat: consolidate yield calculation logic

### DIFF
--- a/backend/src/handlers/dashboard.rs
+++ b/backend/src/handlers/dashboard.rs
@@ -1,11 +1,11 @@
 use crate::errors::AppError;
+use crate::handlers::yield_calc::{calculate_yields, get_capital_for_trade, round2};
 use crate::models::share_lot::ShareLot;
 use crate::models::trade::Trade;
 use axum::{
     extract::{Query, State},
     Json,
 };
-use chrono::NaiveDate;
 use serde::{Deserialize, Serialize};
 use sqlx::SqlitePool;
 
@@ -24,92 +24,31 @@ pub struct DashboardResponse {
     pub active_share_lots: Vec<ShareLot>,
 }
 
-fn days_between(from: &str, to: &str) -> f64 {
-    let parse = |s: &str| NaiveDate::parse_from_str(s, "%Y-%m-%d").ok();
-    match (parse(from), parse(to)) {
-        (Some(f), Some(t)) => (t - f).num_days().max(1) as f64,
-        _ => 1.0,
-    }
-}
-
-fn today() -> String {
-    chrono::Local::now().format("%Y-%m-%d").to_string()
-}
-
-async fn get_capital_for_trade(pool: &SqlitePool, trade: &Trade) -> f64 {
-    let qty = trade.quantity as f64;
-    if trade.trade_type == "PUT" {
-        trade.strike_price * 100.0 * qty
-    } else {
-        // CALL: look up linked lot's adjusted_cost_basis
-        if let Some(lot_id) = trade.share_lot_id {
-            if let Ok(lot) = ShareLot::get(pool, lot_id).await {
-                return lot.adjusted_cost_basis * 100.0 * qty;
-            }
-        }
-        trade.strike_price * 100.0 * qty
-    }
-}
-
 pub async fn get_dashboard(
     State(pool): State<SqlitePool>,
     Query(params): Query<DashboardQuery>,
 ) -> Result<Json<DashboardResponse>, AppError> {
     let trades = Trade::list_with_filters(&pool, params.account_id, None, None, None).await?;
 
+    let yields = calculate_yields(&pool, &trades).await;
+
     let mut total_premium = 0.0;
     let mut open_trades = Vec::new();
-
-    // For weighted average: sum of (yield * capital) and sum of capital
-    let mut realized_weighted_sum = 0.0;
-    let mut realized_capital_sum = 0.0;
-    let mut open_weighted_sum = 0.0;
-    let mut open_capital_sum = 0.0;
     let mut total_capital_deployed = 0.0;
 
-    let today_str = today();
-
     for trade in &trades {
-        let net = trade.net_premium().unwrap_or(0.0);
         let capital = get_capital_for_trade(&pool, trade).await;
 
         if trade.status == "OPEN" {
-            let days = days_between(&trade.open_date, &today_str);
-            let annualized = if capital > 0.0 {
-                (net / capital) * (365.0 / days)
-            } else {
-                0.0
-            };
-            open_weighted_sum += annualized * capital;
-            open_capital_sum += capital;
             open_trades.push(trade.clone());
             total_capital_deployed += capital;
         } else {
-            // Closed trade
-            total_premium += net;
-            let close_date = trade.close_date.as_deref().unwrap_or(&today_str);
-            let days = days_between(&trade.open_date, close_date);
-            let annualized = if capital > 0.0 {
-                (net / capital) * (365.0 / days)
-            } else {
-                0.0
-            };
-            realized_weighted_sum += annualized * capital;
-            realized_capital_sum += capital;
+            total_premium += trade.net_premium().unwrap_or(0.0);
         }
     }
 
-    let realized_annualized_yield = if realized_capital_sum > 0.0 {
-        (realized_weighted_sum / realized_capital_sum) * 100.0
-    } else {
-        0.0
-    };
-
-    let open_annualized_yield = if open_capital_sum > 0.0 {
-        (open_weighted_sum / open_capital_sum) * 100.0
-    } else {
-        0.0
-    };
+    let realized_annualized_yield = yields.realized_yield;
+    let open_annualized_yield = yields.open_yield;
 
     // Fetch active share lots
     let active_share_lots = if let Some(account_id) = params.account_id {
@@ -138,11 +77,9 @@ pub async fn get_dashboard(
         }
     }
 
-    // Round yields to 2 decimal places
-    let realized_annualized_yield = (realized_annualized_yield * 100.0).round() / 100.0;
-    let open_annualized_yield = (open_annualized_yield * 100.0).round() / 100.0;
-    let total_premium = (total_premium * 100.0).round() / 100.0;
-    let total_capital_deployed = (total_capital_deployed * 100.0).round() / 100.0;
+    // Round monetary values to 2 decimal places
+    let total_premium = round2(total_premium);
+    let total_capital_deployed = round2(total_capital_deployed);
 
     Ok(Json(DashboardResponse {
         total_premium_collected: total_premium,

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -5,3 +5,4 @@ pub mod history;
 pub mod puts;
 pub mod share_lots;
 pub mod statistics;
+pub mod yield_calc;

--- a/backend/src/handlers/statistics.rs
+++ b/backend/src/handlers/statistics.rs
@@ -1,5 +1,5 @@
 use crate::errors::AppError;
-use crate::models::share_lot::ShareLot;
+use crate::handlers::yield_calc::{calculate_yields, round2};
 use crate::models::trade::Trade;
 use axum::{
     extract::{Query, State},
@@ -48,10 +48,6 @@ pub struct StatisticsResponse {
 fn month_key(date: &str) -> String {
     // "2025-01-15" -> "2025-01"
     date.get(..7).unwrap_or(date).to_string()
-}
-
-fn round2(v: f64) -> f64 {
-    (v * 100.0).round() / 100.0
 }
 
 pub async fn get_statistics(
@@ -138,58 +134,9 @@ pub async fn get_statistics(
         .collect();
     premium_by_ticker.sort_by(|a, b| b.net_premium.partial_cmp(&a.net_premium).unwrap());
 
-    // Yield calculations (same approach as dashboard, including CALL capital from share lots)
-    let mut realized_weighted = 0.0;
-    let mut realized_capital = 0.0;
-    let mut open_weighted = 0.0;
-    let mut open_capital = 0.0;
-    let today_str = chrono::Local::now().format("%Y-%m-%d").to_string();
-
-    for trade in &trades {
-        let net = trade.net_premium().unwrap_or(0.0);
-        let qty = trade.quantity as f64;
-        let capital = if trade.trade_type == "CALL" {
-            if let Some(lot_id) = trade.share_lot_id {
-                if let Ok(lot) = ShareLot::get(&pool, lot_id).await {
-                    lot.adjusted_cost_basis * 100.0 * qty
-                } else {
-                    trade.strike_price * 100.0 * qty
-                }
-            } else {
-                trade.strike_price * 100.0 * qty
-            }
-        } else {
-            trade.strike_price * 100.0 * qty
-        };
-
-        if trade.status == "OPEN" {
-            let days = days_between(&trade.open_date, &today_str);
-            if capital > 0.0 {
-                let ann = (net / capital) * (365.0 / days);
-                open_weighted += ann * capital;
-                open_capital += capital;
-            }
-        } else {
-            let close_date = trade.close_date.as_deref().unwrap_or(&today_str);
-            let days = days_between(&trade.open_date, close_date);
-            if capital > 0.0 {
-                let ann = (net / capital) * (365.0 / days);
-                realized_weighted += ann * capital;
-                realized_capital += capital;
-            }
-        }
-    }
-
-    let yield_closed = if realized_capital > 0.0 {
-        round2((realized_weighted / realized_capital) * 100.0)
-    } else {
-        0.0
-    };
-    let yield_open = if open_capital > 0.0 {
-        round2((open_weighted / open_capital) * 100.0)
-    } else {
-        0.0
-    };
+    let yields = calculate_yields(&pool, &trades).await;
+    let yield_closed = yields.realized_yield;
+    let yield_open = yields.open_yield;
 
     Ok(Json(StatisticsResponse {
         total_premium: round2(total_premium),
@@ -200,15 +147,6 @@ pub async fn get_statistics(
         cumulative_pnl,
         premium_by_ticker,
     }))
-}
-
-fn days_between(from: &str, to: &str) -> f64 {
-    use chrono::NaiveDate;
-    let parse = |s: &str| NaiveDate::parse_from_str(s, "%Y-%m-%d").ok();
-    match (parse(from), parse(to)) {
-        (Some(f), Some(t)) => (t - f).num_days().max(1) as f64,
-        _ => 1.0,
-    }
 }
 
 #[cfg(test)]

--- a/backend/src/handlers/yield_calc.rs
+++ b/backend/src/handlers/yield_calc.rs
@@ -1,0 +1,261 @@
+use crate::models::share_lot::ShareLot;
+use crate::models::trade::Trade;
+use chrono::NaiveDate;
+use sqlx::SqlitePool;
+
+/// Result of yield calculations across a set of trades.
+#[derive(Debug, Clone)]
+pub struct YieldResult {
+    pub realized_yield: f64,
+    pub open_yield: f64,
+}
+
+/// Calculate capital-weighted annualized yields for a set of trades.
+///
+/// Returns realized (closed) and open annualized yields as percentages,
+/// rounded to 2 decimal places. Used by both dashboard and statistics handlers.
+pub async fn calculate_yields(pool: &SqlitePool, trades: &[Trade]) -> YieldResult {
+    let mut realized_weighted = 0.0;
+    let mut realized_capital = 0.0;
+    let mut open_weighted = 0.0;
+    let mut open_capital = 0.0;
+    let today_str = chrono::Local::now().format("%Y-%m-%d").to_string();
+
+    for trade in trades {
+        let net = trade.net_premium().unwrap_or(0.0);
+        let capital = get_capital_for_trade(pool, trade).await;
+
+        if trade.status == "OPEN" {
+            let days = days_between(&trade.open_date, &today_str);
+            if capital > 0.0 {
+                let ann = (net / capital) * (365.0 / days);
+                open_weighted += ann * capital;
+                open_capital += capital;
+            }
+        } else {
+            let close_date = trade.close_date.as_deref().unwrap_or(&today_str);
+            let days = days_between(&trade.open_date, close_date);
+            if capital > 0.0 {
+                let ann = (net / capital) * (365.0 / days);
+                realized_weighted += ann * capital;
+                realized_capital += capital;
+            }
+        }
+    }
+
+    let realized_yield = if realized_capital > 0.0 {
+        round2((realized_weighted / realized_capital) * 100.0)
+    } else {
+        0.0
+    };
+
+    let open_yield = if open_capital > 0.0 {
+        round2((open_weighted / open_capital) * 100.0)
+    } else {
+        0.0
+    };
+
+    YieldResult {
+        realized_yield,
+        open_yield,
+    }
+}
+
+/// Calculate capital deployed for a trade.
+/// For PUTs: strike_price * 100 * quantity
+/// For CALLs: uses linked share lot's adjusted_cost_basis if available
+pub async fn get_capital_for_trade(pool: &SqlitePool, trade: &Trade) -> f64 {
+    let qty = trade.quantity as f64;
+    if trade.trade_type == "CALL" {
+        if let Some(lot_id) = trade.share_lot_id {
+            if let Ok(lot) = ShareLot::get(pool, lot_id).await {
+                return lot.adjusted_cost_basis * 100.0 * qty;
+            }
+        }
+    }
+    trade.strike_price * 100.0 * qty
+}
+
+pub fn days_between(from: &str, to: &str) -> f64 {
+    let parse = |s: &str| NaiveDate::parse_from_str(s, "%Y-%m-%d").ok();
+    match (parse(from), parse(to)) {
+        (Some(f), Some(t)) => (t - f).num_days().max(1) as f64,
+        _ => 1.0,
+    }
+}
+
+pub fn round2(v: f64) -> f64 {
+    (v * 100.0).round() / 100.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::account::Account;
+    use crate::models::trade::CreateTrade;
+    use crate::{db, models::trade::Trade as TradeModel};
+
+    async fn setup() -> (SqlitePool, i64) {
+        let pool = db::init_pool("sqlite::memory:").await;
+        db::run_migrations(&pool).await;
+        let acct = Account::create(&pool, "Test").await.unwrap();
+        (pool, acct.id)
+    }
+
+    #[test]
+    fn test_days_between_basic() {
+        assert!((days_between("2025-01-01", "2025-01-31") - 30.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_days_between_same_day_returns_one() {
+        assert!((days_between("2025-01-01", "2025-01-01") - 1.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_days_between_invalid_returns_one() {
+        assert!((days_between("bad", "date") - 1.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_round2() {
+        assert!((round2(1.2345) - 1.23).abs() < 0.001);
+        assert!((round2(1.235) - 1.24).abs() < 0.001);
+    }
+
+    #[tokio::test]
+    async fn test_yield_no_trades() {
+        let (pool, _acct_id) = setup().await;
+        let result = calculate_yields(&pool, &[]).await;
+        assert!((result.realized_yield - 0.0).abs() < 0.001);
+        assert!((result.open_yield - 0.0).abs() < 0.001);
+    }
+
+    #[tokio::test]
+    async fn test_yield_closed_trade() {
+        let (pool, acct_id) = setup().await;
+
+        let input = CreateTrade {
+            account_id: acct_id,
+            trade_type: "PUT".to_string(),
+            ticker: "AAPL".to_string(),
+            strike_price: 150.0,
+            expiry_date: "2025-02-21".to_string(),
+            open_date: "2025-01-10".to_string(),
+            premium_received: 200.0,
+            fees_open: 1.3,
+            share_lot_id: None,
+            quantity: Some(1),
+        };
+        let trade = TradeModel::create(&pool, &input).await.unwrap();
+        let closed = TradeModel::close(
+            &pool,
+            trade.id,
+            "EXPIRED",
+            None,
+            None,
+            Some("2025-02-21".to_string()),
+        )
+        .await
+        .unwrap();
+
+        let result = calculate_yields(&pool, &[closed]).await;
+
+        // net_premium = 200 - 1.3 = 198.70
+        // capital = 150 * 100 = 15000
+        // days = 42
+        // annualized = (198.70 / 15000) * (365 / 42) = 0.11511...
+        // yield = 11.51%
+        assert!(result.realized_yield > 11.0 && result.realized_yield < 12.0);
+        assert!((result.open_yield - 0.0).abs() < 0.001);
+    }
+
+    #[tokio::test]
+    async fn test_yield_open_trade() {
+        let (pool, acct_id) = setup().await;
+
+        let input = CreateTrade {
+            account_id: acct_id,
+            trade_type: "PUT".to_string(),
+            ticker: "AAPL".to_string(),
+            strike_price: 150.0,
+            expiry_date: "2025-12-19".to_string(),
+            open_date: "2025-01-10".to_string(),
+            premium_received: 200.0,
+            fees_open: 1.3,
+            share_lot_id: None,
+            quantity: Some(1),
+        };
+        let trade = TradeModel::create(&pool, &input).await.unwrap();
+
+        let result = calculate_yields(&pool, &[trade]).await;
+
+        assert!((result.realized_yield - 0.0).abs() < 0.001);
+        assert!(result.open_yield > 0.0);
+    }
+
+    #[tokio::test]
+    async fn test_yield_matches_dashboard_and_statistics() {
+        // Verify that the shared function produces consistent results
+        // for a mix of open and closed trades
+        let (pool, acct_id) = setup().await;
+
+        let put1 = TradeModel::create(
+            &pool,
+            &CreateTrade {
+                account_id: acct_id,
+                trade_type: "PUT".to_string(),
+                ticker: "AAPL".to_string(),
+                strike_price: 150.0,
+                expiry_date: "2025-02-21".to_string(),
+                open_date: "2025-01-10".to_string(),
+                premium_received: 200.0,
+                fees_open: 1.3,
+                share_lot_id: None,
+                quantity: Some(1),
+            },
+        )
+        .await
+        .unwrap();
+        let closed1 = TradeModel::close(
+            &pool,
+            put1.id,
+            "EXPIRED",
+            None,
+            None,
+            Some("2025-02-21".to_string()),
+        )
+        .await
+        .unwrap();
+
+        let open1 = TradeModel::create(
+            &pool,
+            &CreateTrade {
+                account_id: acct_id,
+                trade_type: "PUT".to_string(),
+                ticker: "MSFT".to_string(),
+                strike_price: 300.0,
+                expiry_date: "2025-12-19".to_string(),
+                open_date: "2025-06-01".to_string(),
+                premium_received: 500.0,
+                fees_open: 2.0,
+                share_lot_id: None,
+                quantity: Some(1),
+            },
+        )
+        .await
+        .unwrap();
+
+        let trades = vec![closed1, open1];
+        let result = calculate_yields(&pool, &trades).await;
+
+        // Both yields should be non-zero
+        assert!(result.realized_yield > 0.0);
+        assert!(result.open_yield > 0.0);
+
+        // Running again with same trades should produce identical results
+        let result2 = calculate_yields(&pool, &trades).await;
+        assert!((result.realized_yield - result2.realized_yield).abs() < 0.001);
+        assert!((result.open_yield - result2.open_yield).abs() < 0.001);
+    }
+}


### PR DESCRIPTION
## Summary
- Extracted duplicated yield calculation from `dashboard.rs` and `statistics.rs` into a shared `yield_calc` module
- New `calculate_yields(pool, trades)` function computes capital-weighted annualized yields (realized + open) for any set of trades
- Also consolidated `get_capital_for_trade()`, `days_between()`, and `round2()` helpers into the shared module
- Net reduction of ~138 lines of duplicated code across both handlers

Closes #23

## Test plan
- [x] All 27 existing tests pass (including dashboard and statistics handler tests)
- [x] 7 new unit tests in `yield_calc` module covering: days_between edge cases, round2, empty trades, open trades, closed trades, and consistency verification
- [x] `cargo check` passes
- [x] Pre-commit hook (rustfmt) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)