### PR TITLE
feat: add edit functionality for trades

### DIFF
--- a/backend/src/handlers/puts.rs
+++ b/backend/src/handlers/puts.rs
@@ -11,7 +11,7 @@ use crate::{
     errors::AppError,
     models::{
         share_lot::ShareLot,
-        trade::{CreateTrade, Trade},
+        trade::{CreateTrade, Trade, UpdateTrade},
     },
 };
 
@@ -149,6 +149,16 @@ pub async fn close_put(
     }
 }
 
+pub async fn edit_trade(
+    State(pool): State<SqlitePool>,
+    Path(trade_id): Path<i64>,
+    Json(payload): Json<UpdateTrade>,
+) -> Result<Json<Trade>, AppError> {
+    let _existing = Trade::get(&pool, trade_id).await?;
+    let updated = Trade::update(&pool, trade_id, &payload).await?;
+    Ok(Json(updated))
+}
+
 #[cfg(test)]
 mod tests {
     use axum::http::StatusCode;
@@ -253,5 +263,85 @@ mod tests {
         // adjusted_cb = 150 - (200 - 1.30) / 100 = 150 - 1.987 = 148.013
         let adjusted = lot["adjusted_cost_basis"].as_f64().unwrap();
         assert!((adjusted - 148.013).abs() < 0.001);
+    }
+
+    #[tokio::test]
+    async fn test_edit_open_trade() {
+        let (server, acct_id) = server().await;
+        let create_res = server
+            .post(&format!("/api/accounts/{}/puts", acct_id))
+            .json(&json!({
+                "ticker": "AAPL",
+                "strike_price": 150.0,
+                "expiry_date": "2025-02-21",
+                "open_date": "2025-01-15",
+                "premium_received": 200.0,
+                "fees_open": 1.30
+            }))
+            .await;
+        let trade_id = create_res.json::<serde_json::Value>()["id"]
+            .as_i64()
+            .unwrap();
+
+        let res = server
+            .put(&format!("/api/trades/{}", trade_id))
+            .json(&json!({
+                "premium_received": 250.0,
+                "fees_open": 2.00,
+                "strike_price": 155.0
+            }))
+            .await;
+        res.assert_status(StatusCode::OK);
+        let body = res.json::<serde_json::Value>();
+        assert_eq!(body["premium_received"], 250.0);
+        assert_eq!(body["fees_open"], 2.0);
+        assert_eq!(body["strike_price"], 155.0);
+        // Unchanged fields should remain
+        assert_eq!(body["ticker"], "AAPL");
+        assert_eq!(body["status"], "OPEN");
+    }
+
+    #[tokio::test]
+    async fn test_edit_closed_trade() {
+        let (server, acct_id) = server().await;
+        let create_res = server
+            .post(&format!("/api/accounts/{}/puts", acct_id))
+            .json(&json!({
+                "ticker": "AAPL",
+                "strike_price": 150.0,
+                "expiry_date": "2025-02-21",
+                "open_date": "2025-01-15",
+                "premium_received": 200.0,
+                "fees_open": 1.30
+            }))
+            .await;
+        let trade_id = create_res.json::<serde_json::Value>()["id"]
+            .as_i64()
+            .unwrap();
+
+        // Close the trade first
+        server
+            .post(&format!("/api/trades/puts/{}/close", trade_id))
+            .json(&json!({
+                "action": "BOUGHT_BACK",
+                "close_date": "2025-02-15",
+                "close_premium": 50.0,
+                "fees_close": 1.30
+            }))
+            .await;
+
+        // Edit the closed trade
+        let res = server
+            .put(&format!("/api/trades/{}", trade_id))
+            .json(&json!({
+                "close_premium": 60.0,
+                "fees_close": 2.00
+            }))
+            .await;
+        res.assert_status(StatusCode::OK);
+        let body = res.json::<serde_json::Value>();
+        assert_eq!(body["close_premium"], 60.0);
+        assert_eq!(body["fees_close"], 2.0);
+        assert_eq!(body["status"], "BOUGHT_BACK");
     }
 }

--- a/backend/src/models/trade.rs
+++ b/backend/src/models/trade.rs
@@ -36,6 +36,19 @@ pub struct CreateTrade {
     pub quantity: Option<i64>,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct UpdateTrade {
+    pub strike_price: Option<f64>,
+    pub expiry_date: Option<String>,
+    pub open_date: Option<String>,
+    pub premium_received: Option<f64>,
+    pub fees_open: Option<f64>,
+    pub quantity: Option<i64>,
+    pub close_date: Option<String>,
+    pub close_premium: Option<f64>,
+    pub fees_close: Option<f64>,
+}
+
 impl Trade {
     pub fn net_premium(&self) -> Option<f64> {
         Some(
@@ -97,6 +110,66 @@ impl Trade {
         .bind(close_premium)
         .bind(fees_close)
         .bind(&date)
+        .bind(id)
+        .execute(pool)
+        .await?;
+
+        if result.rows_affected() == 0 {
+            return Err(AppError::NotFound);
+        }
+
+        Self::get(pool, id).await
+    }
+
+    pub async fn update(
+        pool: &SqlitePool,
+        id: i64,
+        input: &UpdateTrade,
+    ) -> Result<Trade, AppError> {
+        let existing = Self::get(pool, id).await?;
+
+        let strike_price = input.strike_price.unwrap_or(existing.strike_price);
+        let expiry_date = input
+            .expiry_date
+            .clone()
+            .unwrap_or(existing.expiry_date.clone());
+        let open_date = input
+            .open_date
+            .clone()
+            .unwrap_or(existing.open_date.clone());
+        let premium_received = input.premium_received.unwrap_or(existing.premium_received);
+        let fees_open = input.fees_open.unwrap_or(existing.fees_open);
+        let quantity = input.quantity.unwrap_or(existing.quantity);
+
+        // For closed trades, allow editing close fields
+        let close_date = if existing.status != "OPEN" {
+            input.close_date.clone().or(existing.close_date.clone())
+        } else {
+            existing.close_date.clone()
+        };
+        let close_premium = if existing.status != "OPEN" {
+            input.close_premium.or(existing.close_premium)
+        } else {
+            existing.close_premium
+        };
+        let fees_close = if existing.status != "OPEN" {
+            input.fees_close.or(existing.fees_close)
+        } else {
+            existing.fees_close
+        };
+
+        let result = sqlx::query(
+            "UPDATE trades SET strike_price = ?, expiry_date = ?, open_date = ?, premium_received = ?, fees_open = ?, quantity = ?, close_date = ?, close_premium = ?, fees_close = ? WHERE id = ?",
+        )
+        .bind(strike_price)
+        .bind(&expiry_date)
+        .bind(&open_date)
+        .bind(premium_received)
+        .bind(fees_open)
+        .bind(quantity)
+        .bind(&close_date)
+        .bind(close_premium)
+        .bind(fees_close)
         .bind(id)
         .execute(pool)
         .await?;

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -19,6 +19,7 @@ pub fn create_router(pool: SqlitePool) -> Router {
         )
         .route("/api/accounts/:id/puts", post(puts::open_put))
         .route("/api/trades/puts/:id/close", post(puts::close_put))
+        .route("/api/trades/:id", put(puts::edit_trade))
         .route("/api/accounts/:id/calls", post(calls::open_call))
         .route(
             "/api/accounts/:id/share-lots",

--- a/frontend/src/app/history/page.tsx
+++ b/frontend/src/app/history/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { FilterBar } from '@/components/history/FilterBar';
 import { TradeTable } from '@/components/history/TradeTable';
 import { api } from '@/lib/api';
@@ -11,11 +11,11 @@ export default function HistoryPage() {
   const [trades, setTrades] = useState<Trade[]>([]);
   const [filters, setFilters] = useState<HistoryFilters>({});
 
-  const load = (f: HistoryFilters) => {
+  const load = useCallback((f: HistoryFilters) => {
     api.history({ ...f, account_id: selectedAccountId ?? undefined }).then(setTrades);
-  };
+  }, [selectedAccountId]);
 
-  useEffect(() => { load(filters); }, [selectedAccountId, filters]);
+  useEffect(() => { load(filters); }, [load, filters]);
 
   const handleFilterChange = (f: HistoryFilters) => {
     setFilters(f);
@@ -25,7 +25,7 @@ export default function HistoryPage() {
     <div className="space-y-6">
       <h1 className="text-2xl font-bold">Trade History</h1>
       <FilterBar filters={filters} onChange={handleFilterChange} />
-      <TradeTable trades={trades} />
+      <TradeTable trades={trades} onTradeUpdate={() => load(filters)} />
     </div>
   );
 }

--- a/frontend/src/components/dashboard/ActivePositions.tsx
+++ b/frontend/src/components/dashboard/ActivePositions.tsx
@@ -4,6 +4,7 @@ import { Badge } from '@/components/ui/badge';
 import { formatCurrency, daysToExpiry } from '@/lib/utils';
 import { ClosePutModal } from '@/components/trades/ClosePutModal';
 import { CloseCallModal } from '@/components/trades/CloseCallModal';
+import { EditTradeModal } from '@/components/trades/EditTradeModal';
 import type { ShareLot, Trade } from '@/lib/types';
 
 interface Props {
@@ -43,7 +44,8 @@ export function ActivePositions({ openTrades, activeLots, onTradeClose }: Props)
                 <TableCell>{t.expiry_date}</TableCell>
                 <TableCell>{daysToExpiry(t.expiry_date)}d</TableCell>
                 <TableCell>{formatCurrency(t.premium_received)}</TableCell>
-                <TableCell>
+                <TableCell className="space-x-1">
+                  <EditTradeModal trade={t} onSave={onTradeClose ?? (() => {})} />
                   {t.trade_type === 'PUT'
                     ? <ClosePutModal tradeId={t.id} onClose={onTradeClose ?? (() => {})} />
                     : <CloseCallModal tradeId={t.id} onClose={onTradeClose ?? (() => {})} />

--- a/frontend/src/components/history/TradeTable.tsx
+++ b/frontend/src/components/history/TradeTable.tsx
@@ -1,5 +1,7 @@
+'use client';
 import { Badge } from '@/components/ui/badge';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { EditTradeModal } from '@/components/trades/EditTradeModal';
 import { formatCurrency } from '@/lib/utils';
 import type { Trade } from '@/lib/types';
 
@@ -12,9 +14,9 @@ function netPremium(t: Trade): number {
   return t.premium_received - t.fees_open - (t.close_premium ?? 0) - (t.fees_close ?? 0);
 }
 
-interface Props { trades: Trade[]; }
+interface Props { trades: Trade[]; onTradeUpdate?: () => void; }
 
-export function TradeTable({ trades }: Props) {
+export function TradeTable({ trades, onTradeUpdate }: Props) {
   return (
     <Table>
       <TableHeader>
@@ -28,11 +30,12 @@ export function TradeTable({ trades }: Props) {
           <TableHead>Premium</TableHead>
           <TableHead>Net</TableHead>
           <TableHead>Status</TableHead>
+          <TableHead></TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
         {trades.length === 0 && (
-          <TableRow><TableCell colSpan={9} className="text-center text-muted-foreground">No trades found</TableCell></TableRow>
+          <TableRow><TableCell colSpan={10} className="text-center text-muted-foreground">No trades found</TableCell></TableRow>
         )}
         {trades.map((t) => (
           <TableRow key={t.id}>
@@ -47,6 +50,9 @@ export function TradeTable({ trades }: Props) {
               {formatCurrency(netPremium(t))}
             </TableCell>
             <TableCell><Badge variant={STATUS_COLORS[t.status] ?? 'outline'}>{t.status}</Badge></TableCell>
+            <TableCell>
+              <EditTradeModal trade={t} onSave={onTradeUpdate ?? (() => {})} />
+            </TableCell>
           </TableRow>
         ))}
       </TableBody>

--- a/frontend/src/components/trades/EditTradeModal.tsx
+++ b/frontend/src/components/trades/EditTradeModal.tsx
@@ -1,0 +1,108 @@
+'use client';
+import { useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { api } from '@/lib/api';
+import type { Trade } from '@/lib/types';
+
+interface Props {
+  trade: Trade;
+  onSave: () => void;
+}
+
+export function EditTradeModal({ trade, onSave }: Props) {
+  const [open, setOpen] = useState(false);
+  const [strikePrice, setStrikePrice] = useState(String(trade.strike_price));
+  const [expiryDate, setExpiryDate] = useState(trade.expiry_date);
+  const [openDate, setOpenDate] = useState(trade.open_date);
+  const [premiumReceived, setPremiumReceived] = useState(String(trade.premium_received));
+  const [feesOpen, setFeesOpen] = useState(String(trade.fees_open));
+  const [quantity, setQuantity] = useState(String(trade.quantity));
+  const [closeDate, setCloseDate] = useState(trade.close_date ?? '');
+  const [closePremium, setClosePremium] = useState(String(trade.close_premium ?? ''));
+  const [feesClose, setFeesClose] = useState(String(trade.fees_close ?? ''));
+  const [error, setError] = useState('');
+
+  const isClosed = trade.status !== 'OPEN';
+
+  const handleSubmit = async () => {
+    try {
+      const data: Record<string, unknown> = {
+        strike_price: parseFloat(strikePrice),
+        expiry_date: expiryDate,
+        open_date: openDate,
+        premium_received: parseFloat(premiumReceived),
+        fees_open: parseFloat(feesOpen),
+        quantity: parseInt(quantity, 10),
+      };
+      if (isClosed) {
+        if (closeDate) data.close_date = closeDate;
+        if (closePremium) data.close_premium = parseFloat(closePremium);
+        if (feesClose) data.fees_close = parseFloat(feesClose);
+      }
+      await api.trades.edit(trade.id, data);
+      setOpen(false);
+      setError('');
+      onSave();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to update trade');
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger render={<Button size="sm" variant="outline" />}>
+        Edit
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader><DialogTitle>Edit {trade.trade_type} Trade — {trade.ticker}</DialogTitle></DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-1">
+            <Label>Strike Price ($)</Label>
+            <Input type="number" value={strikePrice} onChange={(e) => setStrikePrice(e.target.value)} />
+          </div>
+          <div className="space-y-1">
+            <Label>Open Date</Label>
+            <Input type="date" value={openDate} onChange={(e) => setOpenDate(e.target.value)} />
+          </div>
+          <div className="space-y-1">
+            <Label>Expiry Date</Label>
+            <Input type="date" value={expiryDate} onChange={(e) => setExpiryDate(e.target.value)} />
+          </div>
+          <div className="space-y-1">
+            <Label>Premium Received ($)</Label>
+            <Input type="number" value={premiumReceived} onChange={(e) => setPremiumReceived(e.target.value)} />
+          </div>
+          <div className="space-y-1">
+            <Label>Opening Fees ($)</Label>
+            <Input type="number" value={feesOpen} onChange={(e) => setFeesOpen(e.target.value)} />
+          </div>
+          <div className="space-y-1">
+            <Label>Quantity</Label>
+            <Input type="number" value={quantity} onChange={(e) => setQuantity(e.target.value)} />
+          </div>
+          {isClosed && (
+            <>
+              <div className="space-y-1">
+                <Label>Close Date</Label>
+                <Input type="date" value={closeDate} onChange={(e) => setCloseDate(e.target.value)} />
+              </div>
+              <div className="space-y-1">
+                <Label>Buy Back Premium ($)</Label>
+                <Input type="number" value={closePremium} onChange={(e) => setClosePremium(e.target.value)} />
+              </div>
+              <div className="space-y-1">
+                <Label>Closing Fees ($)</Label>
+                <Input type="number" value={feesClose} onChange={(e) => setFeesClose(e.target.value)} />
+              </div>
+            </>
+          )}
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          <Button className="w-full" onClick={handleSubmit}>Save Changes</Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -20,6 +20,10 @@ export const api = {
     create: (name: string) => request<Account>('/api/accounts', { method: 'POST', body: JSON.stringify({ name }) }),
     delete: (id: number) => request<void>(`/api/accounts/${id}`, { method: 'DELETE' }),
   },
+  trades: {
+    edit: (tradeId: number, data: object) =>
+      request<Trade>(`/api/trades/${tradeId}`, { method: 'PUT', body: JSON.stringify(data) }),
+  },
   puts: {
     open: (accountId: number, data: object) =>
       request<Trade>(`/api/accounts/${accountId}/puts`, { method: 'POST', body: JSON.stringify(data) }),


### PR DESCRIPTION
## Summary
- Add `PUT /api/trades/:id` backend endpoint to update trade fields (strike price, dates, premium, fees, quantity, and close fields for closed trades). Ticker and status are not editable.
- Create `EditTradeModal` component with a form pre-populated with current trade values, showing close fields only for closed trades.
- Add Edit button to both Dashboard (open trades) and History (all trades) pages. Edits trigger data refresh so yield and premium calculations update immediately.

Closes #28

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` passes (29 tests including 2 new: `test_edit_open_trade`, `test_edit_closed_trade`)
- [x] `npm run build` passes
- [x] Manual: Open a trade, click Edit on Dashboard, change premium → verify updated values
- [x] Manual: Close a trade, click Edit on History page, change close premium/fees → verify net premium updates
- [x] Manual: Verify ticker field is not editable in the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)