### PR TITLE
feat: add soft-delete functionality for trades

### DIFF
--- a/backend/src/db/migrations/004_soft_delete_trades.sql
+++ b/backend/src/db/migrations/004_soft_delete_trades.sql
@@ -1,0 +1,2 @@
+-- Add soft-delete support for trades
+ALTER TABLE trades ADD COLUMN deleted_at TEXT;

--- a/backend/src/handlers/dashboard.rs
+++ b/backend/src/handlers/dashboard.rs
@@ -37,6 +37,13 @@ pub async fn get_dashboard(
     let mut total_capital_deployed = 0.0;
 
     for trade in &trades {
+        if trade.deleted_at.is_some() {
+            if trade.status == "OPEN" {
+                open_trades.push(trade.clone());
+            }
+            continue;
+        }
+
         let capital = get_capital_for_trade(&pool, trade).await;
 
         if trade.status == "OPEN" {

--- a/backend/src/handlers/puts.rs
+++ b/backend/src/handlers/puts.rs
@@ -159,6 +159,14 @@ pub async fn edit_trade(
     Ok(Json(updated))
 }
 
+pub async fn delete_trade(
+    State(pool): State<SqlitePool>,
+    Path(trade_id): Path<i64>,
+) -> Result<Json<Trade>, AppError> {
+    let deleted = Trade::soft_delete(&pool, trade_id).await?;
+    Ok(Json(deleted))
+}
+
 #[cfg(test)]
 mod tests {
     use axum::http::StatusCode;
@@ -263,6 +271,39 @@ mod tests {
         // adjusted_cb = 150 - (200 - 1.30) / 100 = 150 - 1.987 = 148.013
         let adjusted = lot["adjusted_cost_basis"].as_f64().unwrap();
         assert!((adjusted - 148.013).abs() < 0.001);
+    }
+
+    #[tokio::test]
+    async fn test_delete_trade() {
+        let (server, acct_id) = server().await;
+        let create_res = server
+            .post(&format!("/api/accounts/{}/puts", acct_id))
+            .json(&json!({
+                "ticker": "AAPL",
+                "strike_price": 150.0,
+                "expiry_date": "2025-02-21",
+                "open_date": "2025-01-15",
+                "premium_received": 200.0,
+                "fees_open": 1.30
+            }))
+            .await;
+        let trade_id = create_res.json::<serde_json::Value>()["id"]
+            .as_i64()
+            .unwrap();
+
+        let res = server.delete(&format!("/api/trades/{}", trade_id)).await;
+        res.assert_status(StatusCode::OK);
+        let body = res.json::<serde_json::Value>();
+        assert!(body["deleted_at"].as_str().is_some());
+
+        // Deleted trade should be excluded from dashboard calculations
+        let dash = server
+            .get(&format!("/api/dashboard?account_id={}", acct_id))
+            .await;
+        let dash_body = dash.json::<serde_json::Value>();
+        assert_eq!(dash_body["total_premium_collected"].as_f64().unwrap(), 0.0);
+        // But should still appear in open_trades list
+        assert_eq!(dash_body["open_trades"].as_array().unwrap().len(), 1);
     }
 
     #[tokio::test]

--- a/backend/src/handlers/statistics.rs
+++ b/backend/src/handlers/statistics.rs
@@ -67,6 +67,10 @@ pub async fn get_statistics(
     let mut ticker_premium: BTreeMap<String, f64> = BTreeMap::new();
 
     for trade in &trades {
+        if trade.deleted_at.is_some() {
+            continue;
+        }
+
         let net = trade.net_premium().unwrap_or(0.0);
 
         // STO income: premium received when opening the trade

--- a/backend/src/handlers/yield_calc.rs
+++ b/backend/src/handlers/yield_calc.rs
@@ -22,6 +22,9 @@ pub async fn calculate_yields(pool: &SqlitePool, trades: &[Trade]) -> YieldResul
     let today_str = chrono::Local::now().format("%Y-%m-%d").to_string();
 
     for trade in trades {
+        if trade.deleted_at.is_some() {
+            continue;
+        }
         let net = trade.net_premium().unwrap_or(0.0);
         let capital = get_capital_for_trade(pool, trade).await;
 

--- a/backend/src/models/trade.rs
+++ b/backend/src/models/trade.rs
@@ -20,6 +20,7 @@ pub struct Trade {
     pub share_lot_id: Option<i64>,
     pub quantity: i64,
     pub created_at: String,
+    pub deleted_at: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -64,7 +65,7 @@ impl Trade {
         let trade = sqlx::query_as::<_, Trade>(
             "INSERT INTO trades (account_id, trade_type, ticker, strike_price, expiry_date, open_date, premium_received, fees_open, share_lot_id, quantity)
              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-             RETURNING id, account_id, trade_type, ticker, strike_price, expiry_date, open_date, premium_received, fees_open, status, close_date, close_premium, fees_close, share_lot_id, quantity, created_at"
+             RETURNING id, account_id, trade_type, ticker, strike_price, expiry_date, open_date, premium_received, fees_open, status, close_date, close_premium, fees_close, share_lot_id, quantity, created_at, deleted_at"
         )
         .bind(input.account_id)
         .bind(&input.trade_type)
@@ -83,7 +84,7 @@ impl Trade {
 
     pub async fn get(pool: &SqlitePool, id: i64) -> Result<Trade, AppError> {
         let trade = sqlx::query_as::<_, Trade>(
-            "SELECT id, account_id, trade_type, ticker, strike_price, expiry_date, open_date, premium_received, fees_open, status, close_date, close_premium, fees_close, share_lot_id, quantity, created_at
+            "SELECT id, account_id, trade_type, ticker, strike_price, expiry_date, open_date, premium_received, fees_open, status, close_date, close_premium, fees_close, share_lot_id, quantity, created_at, deleted_at
              FROM trades WHERE id = ?"
         )
         .bind(id)
@@ -181,10 +182,30 @@ impl Trade {
         Self::get(pool, id).await
     }
 
+    pub async fn soft_delete(pool: &SqlitePool, id: i64) -> Result<Trade, AppError> {
+        let existing = Self::get(pool, id).await?;
+        if existing.deleted_at.is_some() {
+            return Err(AppError::BadRequest("Trade is already deleted".to_string()));
+        }
+
+        let now = chrono::Local::now().format("%Y-%m-%dT%H:%M:%S").to_string();
+        let result = sqlx::query("UPDATE trades SET deleted_at = ? WHERE id = ?")
+            .bind(&now)
+            .bind(id)
+            .execute(pool)
+            .await?;
+
+        if result.rows_affected() == 0 {
+            return Err(AppError::NotFound);
+        }
+
+        Self::get(pool, id).await
+    }
+
     pub async fn list_open(pool: &SqlitePool, account_id: i64) -> Result<Vec<Trade>, AppError> {
         let trades = sqlx::query_as::<_, Trade>(
-            "SELECT id, account_id, trade_type, ticker, strike_price, expiry_date, open_date, premium_received, fees_open, status, close_date, close_premium, fees_close, share_lot_id, quantity, created_at
-             FROM trades WHERE account_id = ? AND status = 'OPEN'"
+            "SELECT id, account_id, trade_type, ticker, strike_price, expiry_date, open_date, premium_received, fees_open, status, close_date, close_premium, fees_close, share_lot_id, quantity, created_at, deleted_at
+             FROM trades WHERE account_id = ? AND status = 'OPEN' AND deleted_at IS NULL"
         )
         .bind(account_id)
         .fetch_all(pool)
@@ -200,7 +221,7 @@ impl Trade {
         date_to: Option<&str>,
     ) -> Result<Vec<Trade>, AppError> {
         let all = sqlx::query_as::<_, Trade>(
-            "SELECT id, account_id, trade_type, ticker, strike_price, expiry_date, open_date, premium_received, fees_open, status, close_date, close_premium, fees_close, share_lot_id, quantity, created_at
+            "SELECT id, account_id, trade_type, ticker, strike_price, expiry_date, open_date, premium_received, fees_open, status, close_date, close_premium, fees_close, share_lot_id, quantity, created_at, deleted_at
              FROM trades ORDER BY open_date DESC"
         )
         .fetch_all(pool)
@@ -282,6 +303,45 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(closed.status, "EXPIRED");
+    }
+
+    #[tokio::test]
+    async fn test_soft_delete() {
+        let (pool, account_id) = setup().await;
+
+        let input = CreateTrade {
+            account_id,
+            trade_type: "PUT".to_string(),
+            ticker: "AAPL".to_string(),
+            strike_price: 150.0,
+            expiry_date: "2025-02-21".to_string(),
+            open_date: "2025-01-15".to_string(),
+            premium_received: 200.0,
+            fees_open: 1.30,
+            share_lot_id: None,
+            quantity: None,
+        };
+
+        let trade = Trade::create(&pool, &input).await.unwrap();
+        assert!(trade.deleted_at.is_none());
+
+        let deleted = Trade::soft_delete(&pool, trade.id).await.unwrap();
+        assert!(deleted.deleted_at.is_some());
+
+        // Soft-deleted trade should not appear in list_open
+        let open = Trade::list_open(&pool, account_id).await.unwrap();
+        assert!(open.is_empty());
+
+        // But should still appear in list_with_filters
+        let all = Trade::list_with_filters(&pool, Some(account_id), None, None, None)
+            .await
+            .unwrap();
+        assert_eq!(all.len(), 1);
+        assert!(all[0].deleted_at.is_some());
+
+        // Deleting again should fail
+        let err = Trade::soft_delete(&pool, trade.id).await;
+        assert!(err.is_err());
     }
 
     #[tokio::test]

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -19,7 +19,10 @@ pub fn create_router(pool: SqlitePool) -> Router {
         )
         .route("/api/accounts/:id/puts", post(puts::open_put))
         .route("/api/trades/puts/:id/close", post(puts::close_put))
-        .route("/api/trades/:id", put(puts::edit_trade))
+        .route(
+            "/api/trades/:id",
+            put(puts::edit_trade).delete(puts::delete_trade),
+        )
         .route("/api/accounts/:id/calls", post(calls::open_call))
         .route(
             "/api/accounts/:id/share-lots",

--- a/frontend/src/components/dashboard/ActivePositions.tsx
+++ b/frontend/src/components/dashboard/ActivePositions.tsx
@@ -1,10 +1,12 @@
 'use client';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { formatCurrency, daysToExpiry } from '@/lib/utils';
 import { ClosePutModal } from '@/components/trades/ClosePutModal';
 import { CloseCallModal } from '@/components/trades/CloseCallModal';
 import { EditTradeModal } from '@/components/trades/EditTradeModal';
+import { api } from '@/lib/api';
 import type { ShareLot, Trade } from '@/lib/types';
 
 interface Props {
@@ -14,6 +16,11 @@ interface Props {
 }
 
 export function ActivePositions({ openTrades, activeLots, onTradeClose }: Props) {
+  const handleDelete = async (tradeId: number) => {
+    await api.trades.delete(tradeId);
+    onTradeClose?.();
+  };
+
   return (
     <div className="space-y-6">
       <div>
@@ -36,20 +43,25 @@ export function ActivePositions({ openTrades, activeLots, onTradeClose }: Props)
               <TableRow><TableCell colSpan={8} className="text-center text-muted-foreground">No open trades</TableCell></TableRow>
             )}
             {openTrades.map((t) => (
-              <TableRow key={t.id}>
-                <TableCell className="font-medium">{t.ticker}</TableCell>
+              <TableRow key={t.id} className={t.deleted_at ? 'opacity-50' : ''}>
+                <TableCell className={`font-medium ${t.deleted_at ? 'line-through' : ''}`}>{t.ticker}</TableCell>
                 <TableCell><Badge variant={t.trade_type === 'PUT' ? 'secondary' : 'default'}>{t.trade_type}</Badge></TableCell>
-                <TableCell>{t.quantity}</TableCell>
-                <TableCell>{formatCurrency(t.strike_price)}</TableCell>
-                <TableCell>{t.expiry_date}</TableCell>
-                <TableCell>{daysToExpiry(t.expiry_date)}d</TableCell>
-                <TableCell>{formatCurrency(t.premium_received)}</TableCell>
+                <TableCell className={t.deleted_at ? 'line-through' : ''}>{t.quantity}</TableCell>
+                <TableCell className={t.deleted_at ? 'line-through' : ''}>{formatCurrency(t.strike_price)}</TableCell>
+                <TableCell className={t.deleted_at ? 'line-through' : ''}>{t.expiry_date}</TableCell>
+                <TableCell className={t.deleted_at ? 'line-through' : ''}>{daysToExpiry(t.expiry_date)}d</TableCell>
+                <TableCell className={t.deleted_at ? 'line-through' : ''}>{formatCurrency(t.premium_received)}</TableCell>
                 <TableCell className="space-x-1">
-                  <EditTradeModal trade={t} onSave={onTradeClose ?? (() => {})} />
-                  {t.trade_type === 'PUT'
-                    ? <ClosePutModal tradeId={t.id} onClose={onTradeClose ?? (() => {})} />
-                    : <CloseCallModal tradeId={t.id} onClose={onTradeClose ?? (() => {})} />
-                  }
+                  {!t.deleted_at && (
+                    <>
+                      <EditTradeModal trade={t} onSave={onTradeClose ?? (() => {})} />
+                      {t.trade_type === 'PUT'
+                        ? <ClosePutModal tradeId={t.id} onClose={onTradeClose ?? (() => {})} />
+                        : <CloseCallModal tradeId={t.id} onClose={onTradeClose ?? (() => {})} />
+                      }
+                      <Button variant="destructive" size="xs" onClick={() => handleDelete(t.id)}>Delete</Button>
+                    </>
+                  )}
                 </TableCell>
               </TableRow>
             ))}

--- a/frontend/src/components/history/TradeTable.tsx
+++ b/frontend/src/components/history/TradeTable.tsx
@@ -1,7 +1,9 @@
 'use client';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { EditTradeModal } from '@/components/trades/EditTradeModal';
+import { api } from '@/lib/api';
 import { formatCurrency } from '@/lib/utils';
 import type { Trade } from '@/lib/types';
 
@@ -17,6 +19,11 @@ function netPremium(t: Trade): number {
 interface Props { trades: Trade[]; onTradeUpdate?: () => void; }
 
 export function TradeTable({ trades, onTradeUpdate }: Props) {
+  const handleDelete = async (tradeId: number) => {
+    await api.trades.delete(tradeId);
+    onTradeUpdate?.();
+  };
+
   return (
     <Table>
       <TableHeader>
@@ -38,20 +45,25 @@ export function TradeTable({ trades, onTradeUpdate }: Props) {
           <TableRow><TableCell colSpan={10} className="text-center text-muted-foreground">No trades found</TableCell></TableRow>
         )}
         {trades.map((t) => (
-          <TableRow key={t.id}>
-            <TableCell className="font-medium">{t.ticker}</TableCell>
+          <TableRow key={t.id} className={t.deleted_at ? 'opacity-50' : ''}>
+            <TableCell className={`font-medium ${t.deleted_at ? 'line-through' : ''}`}>{t.ticker}</TableCell>
             <TableCell><Badge variant={t.trade_type === 'PUT' ? 'secondary' : 'default'}>{t.trade_type}</Badge></TableCell>
-            <TableCell>{t.quantity}</TableCell>
-            <TableCell>{formatCurrency(t.strike_price)}</TableCell>
-            <TableCell>{t.open_date}</TableCell>
-            <TableCell>{t.close_date ?? '—'}</TableCell>
-            <TableCell>{formatCurrency(t.premium_received)}</TableCell>
-            <TableCell className={netPremium(t) >= 0 ? 'text-green-600' : 'text-red-500'}>
+            <TableCell className={t.deleted_at ? 'line-through' : ''}>{t.quantity}</TableCell>
+            <TableCell className={t.deleted_at ? 'line-through' : ''}>{formatCurrency(t.strike_price)}</TableCell>
+            <TableCell className={t.deleted_at ? 'line-through' : ''}>{t.open_date}</TableCell>
+            <TableCell className={t.deleted_at ? 'line-through' : ''}>{t.close_date ?? '—'}</TableCell>
+            <TableCell className={t.deleted_at ? 'line-through' : ''}>{formatCurrency(t.premium_received)}</TableCell>
+            <TableCell className={`${t.deleted_at ? 'line-through ' : ''}${netPremium(t) >= 0 ? 'text-green-600' : 'text-red-500'}`}>
               {formatCurrency(netPremium(t))}
             </TableCell>
             <TableCell><Badge variant={STATUS_COLORS[t.status] ?? 'outline'}>{t.status}</Badge></TableCell>
-            <TableCell>
-              <EditTradeModal trade={t} onSave={onTradeUpdate ?? (() => {})} />
+            <TableCell className="space-x-1">
+              {!t.deleted_at && (
+                <>
+                  <EditTradeModal trade={t} onSave={onTradeUpdate ?? (() => {})} />
+                  <Button variant="destructive" size="xs" onClick={() => handleDelete(t.id)}>Delete</Button>
+                </>
+              )}
             </TableCell>
           </TableRow>
         ))}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -23,6 +23,8 @@ export const api = {
   trades: {
     edit: (tradeId: number, data: object) =>
       request<Trade>(`/api/trades/${tradeId}`, { method: 'PUT', body: JSON.stringify(data) }),
+    delete: (tradeId: number) =>
+      request<Trade>(`/api/trades/${tradeId}`, { method: 'DELETE' }),
   },
   puts: {
     open: (accountId: number, data: object) =>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -24,6 +24,7 @@ export interface Trade {
   share_lot_id: number | null;
   quantity: number;
   created_at: string;
+  deleted_at: string | null;
 }
 
 export type AcquisitionType = 'MANUAL' | 'ASSIGNED';


### PR DESCRIPTION
## Summary
- Adds soft-delete for trades (open or closed) via `DELETE /api/trades/:id` endpoint
- Deleted trades are excluded from all calculations (dashboard metrics, statistics, yield calculations) but remain visible with strike-through styling and reduced opacity on dashboard and history pages
- New migration (004) adds `deleted_at` column to trades table
- Frontend shows delete buttons on both dashboard and history pages; action buttons (edit/close) are hidden for deleted trades

## Test plan
- [x] Backend: `cargo check` passes
- [x] Backend: `cargo test` — all 31 tests pass (including new `test_soft_delete` and `test_delete_trade` tests)
- [x] Frontend: `npm run build` passes
- [x] Pre-commit hooks pass (fmt, eslint, migration test)
- [x] Manual: verify soft-deleted trades show with strike-through on dashboard
- [x] Manual: verify soft-deleted trades show with strike-through on history page
- [x] Manual: verify soft-deleted trades are excluded from statistics

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)