### PR TITLE
fix: roll cost basis reflects blended net immediately

### DIFF
--- a/backend/src/handlers/calls.rs
+++ b/backend/src/handlers/calls.rs
@@ -76,6 +76,14 @@ pub async fn open_call(
 
     if let Some(prev_id) = payload.rolled_from_trade_id {
         Trade::set_rolled_to(&pool, prev_id, trade.id).await?;
+        // The previous call was already closed as BOUGHT_BACK, which may have spiked
+        // the lot's cost basis by a large debit. Now that the roll link is established,
+        // recalculate so the debit is deferred until the new call settles — reflecting
+        // the blended net of both legs to the user immediately.
+        let prev_trade = Trade::get(&pool, prev_id).await?;
+        if let Some(lot_id) = prev_trade.share_lot_id {
+            ShareLot::recalculate_cost_basis(&pool, lot_id).await?;
+        }
     }
 
     Ok((StatusCode::CREATED, Json(trade)))
@@ -120,9 +128,12 @@ pub async fn close_call(
             )
             .await?;
 
-            let net = updated.net_premium().unwrap_or(0.0);
-            ShareLot::reduce_cost_basis(&pool, lot_id, net).await?;
-            let lot = ShareLot::get(&pool, lot_id).await?;
+            // Use full recalculation (not incremental reduce_cost_basis) so that the
+            // roll-aware logic in recalculate_cost_basis can correctly handle the case
+            // where this BOUGHT_BACK call is the "from" leg of a roll: once the new
+            // call's rolled_from link is established (in open_call), recalculate will
+            // exclude this call until the rolled-to call settles.
+            let lot = ShareLot::recalculate_cost_basis(&pool, lot_id).await?;
 
             Ok(Json(json!({
                 "trade": updated,
@@ -140,8 +151,7 @@ pub async fn close_call(
             )
             .await?;
 
-            let net = updated.net_premium().unwrap_or(0.0);
-            ShareLot::reduce_cost_basis(&pool, lot_id, net).await?;
+            ShareLot::recalculate_cost_basis(&pool, lot_id).await?;
             ShareLot::mark_called_away(&pool, lot_id).await?;
 
             Ok(Json(json!(updated)))
@@ -306,5 +316,106 @@ mod tests {
             .await;
         let lots = lots_res.json::<serde_json::Value>();
         assert_eq!(lots.as_array().unwrap().len(), 0);
+    }
+
+    /// Regression: rolling a call at a debit must not spike cost basis until the
+    /// new (rolled-to) call settles. Cost basis should reflect the blended net.
+    #[tokio::test]
+    async fn test_roll_defers_cost_basis_until_settled() {
+        let (server, acct_id, lot_id) = server_with_lot().await;
+
+        // Get baseline cost basis (after PUT assignment)
+        let lots_res = server
+            .get(&format!("/api/accounts/{}/share-lots", acct_id))
+            .await;
+        let baseline_cb = lots_res.json::<serde_json::Value>().as_array().unwrap()[0]
+            ["adjusted_cost_basis"]
+            .as_f64()
+            .unwrap();
+
+        // Open the original call: sold for $150
+        let res = server
+            .post(&format!("/api/accounts/{}/calls", acct_id))
+            .json(&json!({
+                "share_lot_id": lot_id,
+                "ticker": "AAPL",
+                "strike_price": 155.0,
+                "expiry_date": "2025-03-21",
+                "open_date": "2025-02-22",
+                "premium_received": 150.0,
+                "fees_open": 1.30
+            }))
+            .await;
+        let old_call_id = res.json::<serde_json::Value>()["id"].as_i64().unwrap();
+
+        // Close it as BOUGHT_BACK at a big debit ($500) to simulate a debit roll
+        let res = server
+            .post(&format!("/api/trades/calls/{}/close", old_call_id))
+            .json(&json!({
+                "action": "BOUGHT_BACK",
+                "close_date": "2025-03-20",
+                "close_premium": 500.0,
+                "fees_close": 1.30
+            }))
+            .await;
+        res.assert_status(StatusCode::OK);
+        // At this point the roll link is not established yet — cost basis will reflect the debit
+        // (this is expected interim state before the new call is opened)
+
+        // Open the new call (the rolled-to leg): sold for $600
+        let res = server
+            .post(&format!("/api/accounts/{}/calls", acct_id))
+            .json(&json!({
+                "share_lot_id": lot_id,
+                "ticker": "AAPL",
+                "strike_price": 160.0,
+                "expiry_date": "2025-04-18",
+                "open_date": "2025-03-20",
+                "premium_received": 600.0,
+                "fees_open": 1.30,
+                "rolled_from_trade_id": old_call_id
+            }))
+            .await;
+        res.assert_status(StatusCode::CREATED);
+        let new_call_id = res.json::<serde_json::Value>()["id"].as_i64().unwrap();
+
+        // Now the roll is linked. Cost basis should be back to baseline (old call deferred).
+        let lots_res = server
+            .get(&format!("/api/accounts/{}/share-lots", acct_id))
+            .await;
+        let cb_mid_roll = lots_res.json::<serde_json::Value>().as_array().unwrap()[0]
+            ["adjusted_cost_basis"]
+            .as_f64()
+            .unwrap();
+        assert!(
+            (cb_mid_roll - baseline_cb).abs() < 0.001,
+            "mid-roll cost basis should equal baseline ({:.4}), got {:.4}",
+            baseline_cb,
+            cb_mid_roll
+        );
+
+        // Close the new call as EXPIRED — full blended net now applies:
+        // old net = 150 - 1.30 - 500 - 1.30 = -352.60, per_share = -3.526
+        // new net = 600 - 1.30 = 598.70, per_share = 5.987
+        // combined per_share = 2.461 reduction
+        let res = server
+            .post(&format!("/api/trades/calls/{}/close", new_call_id))
+            .json(&json!({
+                "action": "EXPIRED",
+                "close_date": "2025-04-18"
+            }))
+            .await;
+        res.assert_status(StatusCode::OK);
+        let cb_after_roll = res.json::<serde_json::Value>()["share_lot"]["adjusted_cost_basis"]
+            .as_f64()
+            .unwrap();
+
+        let expected = baseline_cb - ((-352.60 + 598.70) / 100.0);
+        assert!(
+            (cb_after_roll - expected).abs() < 0.001,
+            "post-roll cost basis should be {:.4}, got {:.4}",
+            expected,
+            cb_after_roll
+        );
     }
 }

--- a/backend/src/models/share_lot.rs
+++ b/backend/src/models/share_lot.rs
@@ -108,9 +108,38 @@ impl ShareLot {
         Ok(())
     }
 
+    /// Returns true if the terminal trade at the end of a roll chain (following
+    /// rolled_to_trade_id links) is still OPEN. Used to defer cost basis changes
+    /// for in-progress rolls until the final leg settles.
+    async fn roll_chain_terminal_is_open(
+        pool: &SqlitePool,
+        trade_id: i64,
+    ) -> Result<bool, AppError> {
+        let mut current_id = trade_id;
+        loop {
+            let row: Option<(String, Option<i64>)> = sqlx::query_as(
+                "SELECT status, rolled_to_trade_id FROM trades WHERE id = ? AND deleted_at IS NULL",
+            )
+            .bind(current_id)
+            .fetch_optional(pool)
+            .await?;
+
+            match row {
+                None => return Ok(false),
+                Some((_, Some(next_id))) => current_id = next_id,
+                Some((status, None)) => return Ok(status == "OPEN"),
+            }
+        }
+    }
+
     /// Recalculate adjusted_cost_basis for a share lot from scratch.
     /// Computes initial adjusted CB from the source PUT trade (if ASSIGNED),
     /// then subtracts net_premium/lot.quantity for each closed, non-deleted CALL trade.
+    ///
+    /// Roll-aware: a BOUGHT_BACK call that is the "from" leg of an in-progress roll
+    /// is skipped until the terminal call in the chain settles. This ensures the full
+    /// blended net of the roll is applied at once rather than the debit leg appearing
+    /// immediately while the credit leg is deferred.
     pub async fn recalculate_cost_basis(pool: &SqlitePool, id: i64) -> Result<ShareLot, AppError> {
         let lot = Self::get(pool, id).await?;
 
@@ -136,7 +165,10 @@ impl ShareLot {
             }
         }
 
-        // Subtract net premium per share for each closed, non-deleted CALL trade on this lot
+        // Subtract net premium per share for each closed, non-deleted CALL trade on this lot.
+        // Skip calls that are the "from" leg of an in-progress roll (their rolled_to is still
+        // OPEN) — the debit is deferred until the terminal call settles so the full roll net
+        // is reflected as one blended reduction.
         let call_trades = sqlx::query_as::<_, crate::models::trade::Trade>(
             "SELECT id, account_id, trade_type, ticker, strike_price, expiry_date, open_date, premium_received, fees_open, status, close_date, close_premium, fees_close, share_lot_id, quantity, created_at, deleted_at, rolled_from_trade_id, rolled_to_trade_id
              FROM trades WHERE share_lot_id = ? AND trade_type = 'CALL' AND status != 'OPEN' AND deleted_at IS NULL"
@@ -146,6 +178,11 @@ impl ShareLot {
         .await?;
 
         for call in &call_trades {
+            if let Some(rolled_to_id) = call.rolled_to_trade_id {
+                if Self::roll_chain_terminal_is_open(pool, rolled_to_id).await? {
+                    continue;
+                }
+            }
             let net = call.net_premium().unwrap_or(0.0);
             adjusted_cb -= net / lot.quantity as f64;
         }
@@ -230,6 +267,128 @@ mod tests {
 
         let lots = ShareLot::list_active(&pool, account_id).await.unwrap();
         assert_eq!(lots.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_recalculate_defers_roll_in_progress() {
+        // Regression: rolling a call at a debit should not spike cost basis until
+        // the new (rolled-to) call settles.
+        use crate::models::trade::{CreateTrade, Trade};
+
+        let (pool, account_id) = setup().await;
+
+        // Create share lot manually — original_cost_basis is the starting point for
+        // recalculate_cost_basis on MANUAL lots (no PUT trade to look up).
+        let lot = ShareLot::create(
+            &pool,
+            &CreateShareLot {
+                account_id,
+                ticker: "TEST".to_string(),
+                original_cost_basis: 100.0,
+                adjusted_cost_basis: None,
+                acquisition_date: "2025-01-01".to_string(),
+                acquisition_type: "MANUAL".to_string(),
+                source_trade_id: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        // Create old call: sold for $200, bought back for $500 (debit roll)
+        let old_call = Trade::create(
+            &pool,
+            &CreateTrade {
+                account_id,
+                trade_type: "CALL".to_string(),
+                ticker: "TEST".to_string(),
+                strike_price: 105.0,
+                expiry_date: "2025-02-21".to_string(),
+                open_date: "2025-01-15".to_string(),
+                premium_received: 200.0,
+                fees_open: 0.66,
+                share_lot_id: Some(lot.id),
+                quantity: Some(1),
+                rolled_from_trade_id: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        // Close old call as BOUGHT_BACK (debit: net = 200 - 0.66 - 500 - 0.66 = -301.32)
+        Trade::close(
+            &pool,
+            old_call.id,
+            "BOUGHT_BACK",
+            Some(500.0),
+            Some(0.66),
+            Some("2025-02-20".to_string()),
+        )
+        .await
+        .unwrap();
+
+        // Create new call (the rolled-to leg): sold for $600
+        let new_call = Trade::create(
+            &pool,
+            &CreateTrade {
+                account_id,
+                trade_type: "CALL".to_string(),
+                ticker: "TEST".to_string(),
+                strike_price: 110.0,
+                expiry_date: "2025-03-21".to_string(),
+                open_date: "2025-02-20".to_string(),
+                premium_received: 600.0,
+                fees_open: 0.66,
+                share_lot_id: Some(lot.id),
+                quantity: Some(1),
+                rolled_from_trade_id: Some(old_call.id),
+            },
+        )
+        .await
+        .unwrap();
+
+        // Link the roll
+        Trade::set_rolled_to(&pool, old_call.id, new_call.id)
+            .await
+            .unwrap();
+
+        // While new call is OPEN: old call should be excluded — cost basis stays at
+        // original_cost_basis (100.0) with no settled calls contributing.
+        let recalculated = ShareLot::recalculate_cost_basis(&pool, lot.id)
+            .await
+            .unwrap();
+        assert!(
+            (recalculated.adjusted_cost_basis - 100.0).abs() < 0.001,
+            "expected 100.0 while roll is in progress, got {}",
+            recalculated.adjusted_cost_basis
+        );
+
+        // Close new call as EXPIRED (net = 600 - 0.66 = 599.34)
+        Trade::close(
+            &pool,
+            new_call.id,
+            "EXPIRED",
+            None,
+            None,
+            Some("2025-03-21".to_string()),
+        )
+        .await
+        .unwrap();
+
+        // Now both legs are closed. Combined net of the roll:
+        //   old leg: 200 - 0.66 - 500 - 0.66 = -301.32
+        //   new leg: 600 - 0.66        = 599.34
+        //   combined per_share = (-301.32 + 599.34) / 100 = 2.9802
+        //   adjusted_cb = 100.0 - 2.9802 = 97.0198
+        let recalculated = ShareLot::recalculate_cost_basis(&pool, lot.id)
+            .await
+            .unwrap();
+        let expected = 100.0 - ((-301.32 + 599.34) / 100.0);
+        assert!(
+            (recalculated.adjusted_cost_basis - expected).abs() < 0.001,
+            "expected {:.4} after roll settles, got {}",
+            expected,
+            recalculated.adjusted_cost_basis
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **Root cause**: when a covered call is bought back to roll it, `close_call` applied the (often large negative) net immediately via `reduce_cost_basis`, spiking cost basis. The new call's credit wasn't applied until it settled — so the cost basis showed the debit leg alone.
- **Fix**: `recalculate_cost_basis` now skips a BOUGHT_BACK call if its `rolled_to_trade_id` chain terminates at an OPEN trade. When `open_call` establishes the roll link, it triggers a recalculate to immediately reverse the spike. When the rolled-to call eventually closes, both legs are included together as a blended net.
- **Also**: `close_call` now uses `recalculate_cost_basis` instead of incremental `reduce_cost_basis` to ensure the full chain is evaluated on settlement.

## Test plan

- [x] `test_roll_defers_cost_basis_until_settled` — full HTTP-level roll scenario
- [x] `test_recalculate_defers_roll_in_progress` — unit test at model layer
- [x] All 38 existing tests continue to pass
- [ ] After merging and deploying, call `POST /api/share-lots/recalculate` on prod to fix the live CRWV lot (currently at $132.42, should return to ~$117.72)

🤖 Generated with [Claude Code](https://claude.com/claude-code)